### PR TITLE
Add fips check to fbc pipeline and fix violation with one of the used repos

### DIFF
--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -291,6 +291,30 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:c7a6265b875ee3e25183b7eb5d8ab4fc6182c20fe875a47d89d5e92593801270
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -290,6 +290,30 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:c7a6265b875ee3e25183b7eb5d8ab4fc6182c20fe875a47d89d5e92593801270
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -166,7 +166,7 @@ arches:
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/codeready-builder/os/Packages/p/python3-ruamel-yaml-0.16.6-7.el9.1.x86_64.rpm
-    repoid: codeready-builder-for-ubi-9-x86_64
+    repoid: codeready-builder-for-ubi-9-x86_64-rpms
     size: 218621
     checksum: sha256:edfa4be465a7ce774309cf67c85bd1a2f42fb9b5fe2508ccf681605c2ff21ee9
     name: python3-ruamel-yaml


### PR DESCRIPTION
```sh
Results:
✕ [Violation] rpm_repos.ids_known
  ImageRef: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-catalog-ocp4-19@sha256:445cf6918ff9643fa39cab6fca7db0a3ee153361232a3da30c2198748c13d237
  Reason: RPM repo id check failed: An RPM component in the SBOM specified an unknown or disallowed repository_id:
  pkg:rpm/redhat/python3-ruamel-yaml@0.16.6-7.el9.1?arch=x86_64&checksum=sha256:edfa4be465a7ce774309cf67c85bd1a2f42fb9b5fe2508ccf681605c2ff21ee9&repository_id=codeready-builder-for-ubi-9-x86_64
  Title: All rpms have known repo ids
  Description: Each RPM package listed in an SBOM must specify the repository id that it comes from, and that repository id must
  be present in the list of known and permitted repository ids. Currently this is rule enforced only for SBOM components created
  by cachi2. To exclude this rule add
  "rpm_repos.ids_known:pkg:rpm/redhat/python3-ruamel-yaml@0.16.6-7.el9.1?arch=x86_64&checksum=sha256:edfa4be465a7ce774309cf67c85bd1a2f42fb9b5fe2508ccf681605c2ff21ee9&repository_id=codeready-builder-for-ubi-9-x86_64"
  to the `exclude` section of the policy configuration.
  Solution: Ensure every rpm comes from a known and permitted repository, and that the data in the SBOM correctly records that.

✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-catalog-ocp4-19@sha256:445cf6918ff9643fa39cab6fca7db0a3ee153361232a3da30c2198748c13d237
  Reason: One of "fbc-fips-check", "fbc-fips-check-oci-ta" tasks is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:fbc-fips-check", "tasks.required_tasks_found:fbc-fips-check-oci-ta" to the `exclude` section
  of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  https://conforma.dev/docs/ec-cli/configuration.html#_data_sources under the key 'required-tasks'.
```