### PR TITLE
catalog: remove unused kube-rbac-proxy image from index.yaml

### DIFF
--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -988,8 +988,6 @@ properties:
       name: Red Hat
       url: https://www.redhat.com
 relatedImages:
-- image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-  name: ""
 - image: quay.io/bpfman/bpfman-operator-bundle:v0.5.6
   name: ""
 - image: quay.io/bpfman/bpfman-operator:v0.5.6


### PR DESCRIPTION
The kube-rbac-proxy image is no longer referenced by any bundle and can be safely removed from the relatedImages section.
