### PR TITLE
Add ppc64le and s390x architecture support to multi-arch pipeline

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -462,6 +462,8 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms


### PR DESCRIPTION
Extend build-platforms parameter to include linux/ppc64le and linux/s390x architectures alongside existing x86_64 and arm64 support, bringing parity with other OpenShift operator projects.