### PR TITLE
chore: disable renovate for gomod

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
I heard from @frobware that the go update PRs are unwelcome.

According to the renovate documentation:
https://docs.renovatebot.com/modules/manager/#disabling-managers

This is how you disable one of the konflux default managers: https://konflux-ci.dev/docs/mintmaker/user/#available-managers