### PR TITLE
renovate: Enable Go module management but restrict to CVE fixes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,45 @@
 {
+  "extends": [
+    "config:recommended"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "enabled": false
+    }
+  ],
   "gomod": {
-    "enabled": false
+    "enabled": true
+  },
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "go mod tidy",
+      "go mod vendor"
+    ],
+    "fileFilters": [
+      "go.mod",
+      "go.sum",
+      "vendor/**"
+    ]
   }
 }


### PR DESCRIPTION
Previously, Go module updates were disabled in #543. Re-enable Go modules and configure Renovate to open pull requests only for CVE fixes. Add post-upgrade tasks to run go mod tidy and go mod vendor, ensuring go.mod, go.sum and the vendor tree remain consistent and free of stale dependencies.

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1749572770071919?thread_ts=1749490799.440019&cid=C04PZ7H0VA8
