### PR TITLE
go.mod: Switch to Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/bpfman/bpfman-operator
 
-go 1.23.0
-
-toolchain go1.24.2
+go 1.23
 
 require (
 	github.com/bpfman/bpfman v0.5.7-0.20250501125733-0bab1d100f78


### PR DESCRIPTION
Simplify Go version specification in go.mod to use canonical Go 1.23
format and remove explicit toolchain directive.
