### PR TITLE
Fix apply-tags pipeline validation errors

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -297,6 +297,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml
@@ -315,6 +315,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-18-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-18-push.yaml
@@ -313,6 +313,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -339,6 +339,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -340,6 +340,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
@@ -339,6 +339,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -340,6 +340,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-pull-request.yaml
@@ -298,6 +298,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/ocp-bpfman-operator-catalog-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-push.yaml
@@ -295,6 +295,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Add IMAGE_URL and IMAGE_DIGEST parameters to all apply-tags tasks in
Tekton pipelines to resolve validation failures.

https://github.com/openshift/bpfman-operator/pull/558 bumps the
apply-tags parameters requirements. And catalogue builds have been
failing for more than a week.

https://issues.redhat.com/browse/KFLUXSPRT-3675
