### PR TITLE
Fix catalog build failures in hermetic environments

### DIFF
--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
   pipelineSpec:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
   pipelineSpec:


### PR DESCRIPTION
Restrict OCP 4.19 and 4.20 catalog build to x86_64 architecture only. This reverts https://github.com/openshift/bpfman-operator/pull/519/commits/aef547e1aefe15318b99ae76611e2d534331450b.