### PR TITLE
Fix hermetic multi-architecture catalog builds

### DIFF
--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
   pipelineSpec:

--- a/Containerfile.catalog.openshift-4.19
+++ b/Containerfile.catalog.openshift-4.19
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest as builder-runner
-RUN dnf install -y skopeo jq python3 python3-ruamel-yaml-clib python3-ruamel-yaml
+RUN dnf install -y skopeo jq
 
 # Use a new stage to enable caching of the package installations for local development
 FROM builder-runner as builder

--- a/Containerfile.catalog.openshift-4.19
+++ b/Containerfile.catalog.openshift-4.19
@@ -1,5 +1,13 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest as builder-runner
-RUN dnf install -y skopeo jq
+
+# Use Cachi2 prefetched dependencies instead of live dnf install
+# This allows hermetic builds while still installing required packages
+RUN if [ -f /tmp/cachi2/cachi2.env ]; then \
+      . /tmp/cachi2/cachi2.env && \
+      microdnf install -y skopeo jq; \
+    else \
+      dnf install -y skopeo jq; \
+    fi
 
 # Use a new stage to enable caching of the package installations for local development
 FROM builder-runner as builder

--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -14,38 +14,5 @@ sed -i -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSP
 sed -i -e "s|quay.io/bpfman/bpfman-operator-bundle:v.*|\"${BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC}\"|g" \
 	"${INDEX_FILE}"
 
-# time for some direct modifications to the csv
-python3 - << INDEX_FILE_UPDATE
-import os
-from collections import OrderedDict
-from sys import exit as sys_exit
-from datetime import datetime
-from ruamel.yaml import YAML
-yaml = YAML()
-def load_manifest(pathn):
-   if not pathn.endswith(".yaml"):
-      return None
-   try:
-      with open(pathn, "r") as f:
-         return list(yaml.load_all(f))
-   except FileNotFoundError:
-      print("File can not found")
-      exit(2)
-
-def dump_manifest(pathn, manifest):
-   with open(pathn, "w") as f:
-      yaml.dump_all(manifest, f)
-   return
-
-manifest = load_manifest(os.getenv('INDEX_FILE'))
-
-if manifest is not None:
-    # Iterate over the loaded manifest and update the 'image' field
-    for index_file in manifest:
-        index_file['image'] = os.getenv('BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC', '')
-    # Dump the updated manifest back into the file
-    dump_manifest(os.getenv('INDEX_FILE'), manifest)
-
-INDEX_FILE_UPDATE
 
 cat $INDEX_FILE

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,8 +1,9 @@
 contentOrigin:
   repofiles:
     - ./ubi.repo
-packages: [skopeo, jq, python3, python3-ruamel-yaml-clib, python3-ruamel-yaml]
+packages: [skopeo, jq]
+arches: [x86_64, aarch64, ppc64le, s390x]
 context:
   containerfile:
-    file: Containerfile.catalog.openshift-4.18
+    file: Containerfile.catalog.openshift-4.19
     stageName: builder-runner

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -2,22 +2,426 @@
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
+- arch: aarch64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/containers-common-1-117.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 158379
+    checksum: sha256:5571ade0c71bbf0266315f2584693de7e517df4fe6b0ea0e84381030573b08d9
+    name: containers-common
+    evr: 2:1-117.el9_6
+    sourcerpm: containers-common-1-117.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-3.19-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 560401
+    checksum: sha256:a8d48e547151607ef6b4e2e83d7207c6a5de350a3ae68f0c9a0ee92745d36e1d
+    name: criu
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 32980
+    checksum: sha256:935aa34ce481fa755270cb502cad148c9b443d48a3994a481d65a23d21ac3844
+    name: criu-libs
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/crun-1.21-1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 224882
+    checksum: sha256:3a243244600c98c87cdd18903f86c1980c530114e666383555989dc0c45f11a3
+    name: crun
+    evr: 1.21-1.el9_6
+    sourcerpm: crun-1.21-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 66963
+    checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 58189
+    checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
+    name: fuse3
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 92984
+    checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
+    name: fuse3-libs
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/j/jq-1.6-15.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 187128
+    checksum: sha256:e21b572bcb332664bb342fe53d5ced4714ccd5008f2170049ef77fa2162183a0
+    name: jq
+    evr: 1.6-15.el9
+    sourcerpm: jq-1.6-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 62963
+    checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
+    name: libnet
+    evr: 1.2-7.el9
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 70971
+    checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 222582
+    checksum: sha256:bc2305dad655ddb94f966158112efd6cefa6824d5aa2e80f63881f16cee74598
+    name: oniguruma
+    evr: 6.9.6-1.el9.5
+    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 8690432
+    checksum: sha256:fe2365bf0f27bcf3682e2accce4703dcf8be26ce0918bb16e200bd407e8aa12c
+    name: skopeo
+    evr: 2:1.18.1-2.el9_6
+    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 50394
+    checksum: sha256:01db172d566e090d3a0789d27c3dd7d7151458765b6264784e0fa3d89b132fee
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+    sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/y/yajl-2.1.0-25.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 42219
+    checksum: sha256:a6becc709b5431b18ccebd844278598f01f05bfd57dc1abfaa1680d5b8edc8ac
+    name: yajl
+    evr: 2.1.0-25.el9
+    sourcerpm: yajl-2.1.0-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 8718
+    checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 130824
+    checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 363241
+    checksum: sha256:91c7bf60c756cd2a457652b95e96e725068898f4ce580b70784fc60a099621b5
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 38582
+    checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 89073
+    checksum: sha256:defb5583bcda27004a657df50d385d9884a0d93b14c38725b1141255614dcd0c
+    name: shadow-utils-subid
+    evr: 2:4.9-12.el9
+    sourcerpm: shadow-utils-4.9-12.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: ppc64le
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/containers-common-1-117.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 158353
+    checksum: sha256:d69a20c9463d424df9c50fdefb91a10f7cd4e9e98d65b32739f0bc7412aba84d
+    name: containers-common
+    evr: 2:1-117.el9_6
+    sourcerpm: containers-common-1-117.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/criu-3.19-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 608452
+    checksum: sha256:2fd5ef4565faf84bdf39277d4a7206adde0887dce847f8267d01075540e3f3a7
+    name: criu
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/criu-libs-3.19-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 35368
+    checksum: sha256:4e06383e49aba63f146f224f63d5ae211c33850ef8216dd36e75041904d815fd
+    name: criu-libs
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/crun-1.21-1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 261892
+    checksum: sha256:ccd495b539bd5a3d90729dd4b1ae3ef1d5f8c60dd3f07bbcc5afaef969e57ebc
+    name: crun
+    evr: 1.21-1.el9_6
+    sourcerpm: crun-1.21-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 72573
+    checksum: sha256:e75b7ccde7aeddf184db04d818e89ef79d3f664497799b9b135ef10fff2a084c
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/f/fuse3-3.10.2-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 60949
+    checksum: sha256:2d3079c155a9d6b0184fdf4147f814260008877091cc47127cc6a2b04cc4d77b
+    name: fuse3
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 101678
+    checksum: sha256:3a8609dbd730ac88e7dfd9fcf1e553a549f38c81e9ddd74d3a5b65e5f1bb4d1b
+    name: fuse3-libs
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/j/jq-1.6-15.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 207041
+    checksum: sha256:f1e01ff06dee639c707ff605d9566b8dd9a962bd61845ce2fcdb426dfcb007c6
+    name: jq
+    evr: 1.6-15.el9
+    sourcerpm: jq-1.6-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libnet-1.2-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 69085
+    checksum: sha256:6e3fc7cecfb5f2cf5121876958491c773287c72449e0331493fc3d1fa15740fd
+    name: libnet
+    evr: 1.2-7.el9
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libslirp-4.4.0-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 76756
+    checksum: sha256:d7cde72fc007d27edaf44c1743d37dc0a1d01fb456d9bc83fee5688c906dadf0
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 246370
+    checksum: sha256:0b700ed36523819c0dd5066cf5835c7ffb3691dbc13657e3f49acc71635fd6a6
+    name: oniguruma
+    evr: 6.9.6-1.el9.5
+    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 8780483
+    checksum: sha256:ea9a4277afb3ea0937a367930f2762db48e453d46b03c936a675609b75077a47
+    name: skopeo
+    evr: 2:1.18.1-2.el9_6
+    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 52666
+    checksum: sha256:890db2a14491bda11835eee68db88dc53150b6b60db2164d09e8878b1e068e20
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+    sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/y/yajl-2.1.0-25.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 44667
+    checksum: sha256:26fab003ba430cebc0b15182be8f43799af55dbd618bc64fece8aaba7081dcc4
+    name: yajl
+    evr: 2.1.0-25.el9
+    sourcerpm: yajl-2.1.0-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 8730
+    checksum: sha256:e165849a1cf2650552dae0735f29d5d2cdca20a3bc12afd7978cc8292207dd2c
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/k/kmod-28-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 144897
+    checksum: sha256:b2ad04f06f82864fd93ac6fd96fdedcaf90a498194b36b046e952ae8385e1b83
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libnl3-3.11.0-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 393979
+    checksum: sha256:3f75460b21f4bd370d1bbb39a0cf54b27279f7d45bcf65420bebd350eb9f100e
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 41163
+    checksum: sha256:68f122113847f244a3fb8f65c25fcc1cd76ac13f79e35e313c4f46a8f1efd2f0
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 100960
+    checksum: sha256:dc655effd02dcea866f5213acce12dcec362a0c8c928e243811ce748b7d0f0a8
+    name: shadow-utils-subid
+    evr: 2:4.9-12.el9
+    sourcerpm: shadow-utils-4.9-12.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: s390x
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/containers-common-1-117.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 158384
+    checksum: sha256:43f617e6883b9888af1d8cd5a97ff4bccc145839a1cffa7c3d07b5d0b27effa5
+    name: containers-common
+    evr: 2:1-117.el9_6
+    sourcerpm: containers-common-1-117.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/criu-3.19-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 543056
+    checksum: sha256:c6e2b1e4a66c5face9a09770caeff4afb4ac5921c0bd06a2862a2e4cf10914fa
+    name: criu
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/criu-libs-3.19-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32946
+    checksum: sha256:8cd82350b1ebfd686c791c4332b41140f9f7e985f939b7054f0e358f956f05ff
+    name: criu-libs
+    evr: 3.19-1.el9
+    sourcerpm: criu-3.19-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/crun-1.21-1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 222005
+    checksum: sha256:0a3c63059d8677115ae9a5e5e32d575dca00ccb05f0df96f3f434eff7eadd312
+    name: crun
+    evr: 1.21-1.el9_6
+    sourcerpm: crun-1.21-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 67551
+    checksum: sha256:93f1e55607f125f9cee078491ac5e283b27ca8e0f715a2925dc7cd9f2373a340
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+    sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/f/fuse3-3.10.2-9.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 58849
+    checksum: sha256:268c49edce99e99b8d4259dc9ef7f77df26112c2f83197bda44d59ccfb9455c0
+    name: fuse3
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 91494
+    checksum: sha256:0dabf755fc8193b5d412f96f25693d0d7f782e018c0809ea60aaaa5cfa3bcf3d
+    name: fuse3-libs
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/j/jq-1.6-15.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 203811
+    checksum: sha256:71fb2e4304ac31cd465b213e582e43bd888df76d0b15a2eb687d9f0ba05af091
+    name: jq
+    evr: 1.6-15.el9
+    sourcerpm: jq-1.6-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libnet-1.2-7.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 58422
+    checksum: sha256:3e4a676c2278bb717d3ca2136e2af3887169d4f773a3a0fd7da63523dcaa7055
+    name: libnet
+    evr: 1.2-7.el9
+    sourcerpm: libnet-1.2-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libslirp-4.4.0-8.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 68715
+    checksum: sha256:b40578b6b3d8b07bf72e3a6436b2950f5186daf697be465df49bec4258559619
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 225810
+    checksum: sha256:02fab0b52c89158bd45ccc575ccc9186f196fc514eccd66ebfc72c6b0a08849f
+    name: oniguruma
+    evr: 6.9.6-1.el9.5
+    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9000980
+    checksum: sha256:7369b926ac4e07cd3bc25a5c546214bc67514996343c15145b0c38e08afeff85
+    name: skopeo
+    evr: 2:1.18.1-2.el9_6
+    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 50223
+    checksum: sha256:09569926443a6a55fc83ab3f527ba2f7615132dece1ba6c907756b1f5c122a17
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+    sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/y/yajl-2.1.0-25.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 41891
+    checksum: sha256:479b9f5c4422e460fa6b3cd8cb076cfec9ee7278e98f2054eeab2eeea546d7e1
+    name: yajl
+    evr: 2.1.0-25.el9
+    sourcerpm: yajl-2.1.0-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 8730
+    checksum: sha256:c5f5c7c16721d91391b87ea2aecba0a5c88bab353b4e49fc95b84a931ecd7297
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/k/kmod-28-10.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 131701
+    checksum: sha256:fa01c99cf0fe119789f1774fd1f4c469e5e6ef6557d274c1c48bf7ddd780dbcd
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libnl3-3.11.0-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 361754
+    checksum: sha256:70386e84521e5d56acdbc69f598b42de07b5a2b62756f3be1a7a90e82bf23502
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 38450
+    checksum: sha256:0ba1d0bcbc80c2dc53fdac3eecf2606aab133ca22ba7cf857d720c78cb120782
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 88896
+    checksum: sha256:30aabdf564499f7a95c4e8d71f2d9fd7c9f2921ef3180378939ed15571ac38a9
+    name: shadow-utils-subid
+    evr: 2:4.9-12.el9
+    sourcerpm: shadow-utils-4.9-12.el9.src.rpm
+  source: []
+  module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/container-selinux-2.232.1-1.el9.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 61729
-    checksum: sha256:0b79c666cfec3021b19a1e5e298340d1310c110e67f35e75a60ed28838a9f658
-    name: container-selinux
-    evr: 3:2.232.1-1.el9
-    sourcerpm: container-selinux-2.232.1-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/containers-common-1-96.el9_5.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 148067
-    checksum: sha256:e8f54f5b0699c9fa69bd0a54f78f84ec8cf8c36fdd39a2a7ecc8c86e06fffb7d
+    size: 158417
+    checksum: sha256:4a45b00847d30c3c804a6184af69e0e11836be975e51960596ce31c459a5d532
     name: containers-common
-    evr: 2:1-96.el9_5
-    sourcerpm: containers-common-1-96.el9_5.src.rpm
+    evr: 2:1-117.el9_6
+    sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/criu-3.19-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 576009
@@ -32,13 +436,13 @@ arches:
     name: criu-libs
     evr: 3.19-1.el9
     sourcerpm: criu-3.19-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.16.1-1.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.21-1.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 231179
-    checksum: sha256:799e1b2c4c898c72ccf45118bee379d1a2c427948be07efe547e43cbbda454a4
+    size: 239763
+    checksum: sha256:08c8037c221ccc2f940b0a6c549a1ec1497198f8876214048aacacb272d25392
     name: crun
-    evr: 1.16.1-1.el9
-    sourcerpm: crun-1.16.1-1.el9.src.rpm
+    evr: 1.21-1.el9_6
+    sourcerpm: crun-1.21-1.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 71022
@@ -88,41 +492,27 @@ arches:
     name: oniguruma
     evr: 6.9.6-1.el9.5
     sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-ruamel-yaml-clib-0.2.7-3.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 151468
-    checksum: sha256:e7c146794a3e4ea343c32e68a3071ba72c941624f6340ede8bba60ff09d00851
-    name: python3-ruamel-yaml-clib
-    evr: 0.2.7-3.el9
-    sourcerpm: python-ruamel-yaml-clib-0.2.7-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/skopeo-1.16.1-2.el9_5.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 9199290
-    checksum: sha256:9ee81140efbcd9b024bfc40fb3572a17b64c81831184d90ac8babb52f4949bf7
+    size: 9530108
+    checksum: sha256:039405094c2d9a353471b7c14a4cd1acde857472f2692b33ca486386a56f8cdc
     name: skopeo
-    evr: 2:1.16.1-2.el9_5
-    sourcerpm: skopeo-1.16.1-2.el9_5.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.1-1.el9.x86_64.rpm
+    evr: 2:1.18.1-2.el9_6
+    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 50412
-    checksum: sha256:ddfeed233ab33a8eaf5dabf37e688398c9801f28822f411fa94e7b134cfd4ae6
+    size: 50387
+    checksum: sha256:25a2a6c5cee50c6f4693ee66c782e9644f4ba1fe410c795391afcc07546496e7
     name: slirp4netns
-    evr: 1.3.1-1.el9
-    sourcerpm: slirp4netns-1.3.1-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/y/yajl-2.1.0-22.el9.x86_64.rpm
+    evr: 1.3.2-1.el9
+    sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/y/yajl-2.1.0-25.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 42586
-    checksum: sha256:e130574b0923861bfda720449d00cef5e2dfb13b1da94d5143354b3f2b10709c
+    size: 42487
+    checksum: sha256:f7503f34d5095303db5c57c70c5edb890dab7d0bba5920f3dcc44d7835449555
     name: yajl
-    evr: 2.1.0-22.el9
-    sourcerpm: yajl-2.1.0-22.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 411559
-    checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
-    name: diffutils
-    evr: 3.7-12.el9
-    sourcerpm: diffutils-3.7-12.el9.src.rpm
+    evr: 2.1.0-25.el9
+    sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 8750
@@ -137,27 +527,13 @@ arches:
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 367914
-    checksum: sha256:f436a96ba3433f501a7015bec2fa35ac05b52b776f0256b9c8cb3e6268086817
+    size: 376137
+    checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
     name: libnl3
-    evr: 3.9.0-1.el9
-    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-1.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 198772
-    checksum: sha256:479229e7c3d8cb005dafd637b2973fbee0bb507cfed8e72f7076318513200abd
-    name: libselinux-utils
-    evr: 3.6-1.el9
-    sourcerpm: libselinux-3.6-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 251967
-    checksum: sha256:8dcd39960d3103f7a4ad2b9f7a0e15469ebf4da98f6c215cddfffdb830dc12b5
-    name: policycoreutils
-    evr: 3.6-2.1.el9
-    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 38224
@@ -165,12 +541,12 @@ arches:
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/codeready-builder/os/Packages/p/python3-ruamel-yaml-0.16.6-7.el9.1.x86_64.rpm
-    repoid: codeready-builder-for-ubi-9-x86_64-rpms
-    size: 218621
-    checksum: sha256:edfa4be465a7ce774309cf67c85bd1a2f42fb9b5fe2508ccf681605c2ff21ee9
-    name: python3-ruamel-yaml
-    evr: 0.16.6-7.el9.1
-    sourcerpm: python-ruamel-yaml-0.16.6-7.el9.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 90389
+    checksum: sha256:342ced93b6ca9b0fd884f990177f7b1e8a6bc35e0bb2a6d4b6684cf8f0062760
+    name: shadow-utils-subid
+    evr: 2:4.9-12.el9
+    sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
The OCP 4.19 catalog builds were failing on non-x86_64 architectures (aarch64, ppc64le, s390x) when running in hermetic mode due to missing Python dependencies:

```
ERROR:dnf:No match for argument: python3-ruamel-yaml
ERROR:root:Problems in request:
missing packages: python3-ruamel-yaml
```

The root cause was that `python3-ruamel-yaml` and related packages are not available in UBI9 repositories for all architectures, causing dependency resolution failures during hermetic builds where network access is disabled.

## Solution

This PR tries to fix with four key changes:

### 1. **Enable multi-architecture builds**
- Restored support for `linux/x86_64`, `linux/arm64`, `linux/ppc64le`, `linux/s390x` in the Tekton pipeline
- Catalog images contain only metadata files, not architecture-specific binaries

### 2. **Eliminate Python dependencies**  
- Replaced complex `ruamel.yaml` Python processing with simple `sed` commands
- The script only needs to update image references in YAML, which `sed` handles reliably
- Removed all Python packages from the build requirements

### 3. **Update RPM lockfile for all architectures** 
- Extended `rpms.in.yaml` to include `arches: [x86_64, aarch64, ppc64le, s390x]`
- Regenerated `rpms.lock.yaml` with packages cached for all target architectures
- Simplified package list to only essential tools: `skopeo`, `jq`

### 4. **Integrate Cachi2 hermetic build support** 
- Added conditional logic to detect and use Cachi2 prefetched dependencies
- Falls back to live `dnf` for local development builds
- Ensures hermetic builds work with cached RPM packages

