### PR TITLE
Fix Tekton pipeline triggers for release-4.19 branch

### DIFF
--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19


### PR DESCRIPTION
Updates target branch condition from "main" to "release-4.19" in
both pull request and push pipeline triggers to ensure proper
activation on the release branch.
