### PR TITLE
Update catalog build process to set createdAt timestamp

### DIFF
--- a/hack/patch_catalog_build_date.py
+++ b/hack/patch_catalog_build_date.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from datetime import datetime
+from ruamel.yaml import YAML
+
+def update_catalog_timestamp(catalog_file):
+    """Update the createdAt timestamp in a catalog file"""
+    yaml = YAML()
+
+    with open(catalog_file, 'r') as f:
+        docs = list(yaml.load_all(f))
+
+    current_time = datetime.now().strftime('%d %b %Y, %H:%M')
+
+    for doc in docs:
+        if doc and doc.get('schema') == 'olm.bundle':
+            # The createdAt field is in properties -> olm.csv.metadata -> value -> annotations
+            if 'properties' in doc:
+                for prop in doc['properties']:
+                    if prop.get('type') == 'olm.csv.metadata':
+                        if 'value' in prop and 'annotations' in prop['value']:
+                            annotations = prop['value']['annotations']
+                            if 'createdAt' in annotations:
+                                annotations['createdAt'] = current_time
+
+    with open(catalog_file, 'w') as f:
+        yaml.dump_all(docs, f)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: patch_catalog_build_date.py <catalog_file>", file=sys.stderr)
+        sys.exit(1)
+
+    update_catalog_timestamp(sys.argv[1])

--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -46,6 +46,9 @@ if manifest is not None:
 
 INDEX_FILE_UPDATE
 
+# Update catalog timestamp
+hack/patch_catalog_build_date.py "${INDEX_FILE}"
+
 if command -v diff >/dev/null 2>&1; then
     echo "Changes made:"
     diff -u "${INDEX_FILE}.bak" "${INDEX_FILE}" || true


### PR DESCRIPTION
The catalog's createdAt field was previously static, showing an
outdated date in the OpenShift console. This change ensures the
catalog reflects when it was actually built.

Changes:
- Add patch_catalog_release_date.py script to update catalog timestamps
- Modify update_catalog.sh to call the new timestamp update script

The catalog's createdAt date now updates dynamically during the build
process, providing users with accurate information about catalog
freshness in the OpenShift console.
