### PR TITLE
Fix hermetic task violation in buildah-remote-oci-ta task

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -433,7 +433,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: 'false'
+  - default: 'true'
     description: Execute the build with network isolation
     name: hermetic
     type: string


### PR DESCRIPTION
Update Pipeline template files to default hermetic parameter to 'true'
instead of 'false' to ensure hermetic builds are enforced by default.

This attempts to resolve the following Konflux policy violation:

✕ [Violation] hermetic_task.hermetic
  ImageRef: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator@sha256:ee38d800434211ccf7700df0b9856e5affab35aafd0b957191251f19451c9147
  Reason: Task 'buildah-remote-oci-ta' was not invoked with the hermetic parameter set
  Title: Task called with hermetic param set
  Description: Verify the task in the PipelineRun attestation was invoked with the proper parameters to make the task execution
  hermetic. To exclude this rule add "hermetic_task.hermetic" to the `exclude` section of the policy configuration.
  Solution: Make sure the task has the input parameter 'HERMETIC' set to 'true'.
