### PR TITLE
Migrate source-build-oci-ta task to support 0.3 parameter changes

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -156,7 +156,9 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: BINARY_IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -132,7 +132,9 @@ spec:
       - build-container
       params:
       - name: BINARY_IMAGE
-        value: "$(params.output-image)"
+        value: "$(tasks.build-container.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-container.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
Update both multi-arch and single-arch build pipelines to include the
new BINARY_IMAGE_DIGEST parameter required by the source-build-oci-ta
task version 0.3 migration. The multi-arch pipeline now uses
build-image-index task results whilst the single-arch pipeline uses
build-container task results for both BINARY_IMAGE and
BINARY_IMAGE_DIGEST parameters.

Migration reference: https://github.com/konflux-ci/build-definitions/blob/main/task/source-build-oci-ta/0.3/MIGRATION.md
