### PR TITLE
hack/update_catalog: Add comment markers to reduce merge conflicts

### DIFF
--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-#!/usr/bin/env bash
-
+# Do not remove empty lines, they are there to reduce conflicts.
 export BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC="registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:23c181a6ea490d38c419778cdb8b43b1f904e0df5caae3d553e5f0c888373341"
+#
 export BPFMAN_OPERATOR_IMAGE_PULLSPEC="registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:a9d5a69142daf94fa95fd0bbb5b0a67e97a050ecc5e41b23252f20ceaac92c0c"
-
-
+#
 export INDEX_FILE=/configs/bpfman-operator/index.yaml
 
 # Create backup for diff


### PR DESCRIPTION
Idea taken from https://github.com/netobserv/network-observability-operator/blob/fd979411a12ed7a523cf4b61dd7df348ac1ad40a/hack/nudging/container_digest.sh
