### PR TITLE
Disable profiling port in bpfman-agent to avoid host network conflicts

### DIFF
--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -116,7 +116,7 @@ spec:
           command: [/bpfman-agent]
           args:
             - --health-probe-bind-address=:8175
-            - --profiling-bind-address=:6060
+            # - --profiling-bind-address=:6060
           image: quay.io/bpfman/bpfman-agent:latest
           securityContext:
             privileged: true


### PR DESCRIPTION
This is a cherry-pick of https://github.com/bpfman/bpfman-operator/pull/458.

The bpfman-agent runs with hostNetwork=true, causing port 6060 to be
bound on every node. Since there is currently no configuration option
in the bpfman-config ConfigMap to disable or change this port, the
hardcoded profiling argument is commented out.

This change allows production deployments to proceed without port
conflicts whilst preserving the profiling capability for development
environments where it can be easily uncommented and re-enabled as
needed.
