### PR TITLE
Revert "Add hermetic parameter to operator, agent, and bundle pipelines"

### DIFF
--- a/.tekton/ocp-bpfman-agent-pull-request.yaml
+++ b/.tekton/ocp-bpfman-agent-pull-request.yaml
@@ -35,8 +35,6 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile.bpfman-agent.openshift
-  - name: hermetic
-    value: 'true'
   - name: path-context
     value: .
   - name: build-platforms

--- a/.tekton/ocp-bpfman-agent-push.yaml
+++ b/.tekton/ocp-bpfman-agent-push.yaml
@@ -33,8 +33,6 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-agent:{{revision}}
   - name: dockerfile
     value: Containerfile.bpfman-agent.openshift
-  - name: hermetic
-    value: 'true'
   - name: path-context
     value: .
   - name: build-platforms

--- a/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile.bundle.openshift
-  - name: hermetic
-    value: 'true'
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -32,8 +32,6 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-bundle:{{revision}}
   - name: dockerfile
     value: Containerfile.bundle.openshift
-  - name: hermetic
-    value: 'true'
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-pull-request.yaml
@@ -35,8 +35,6 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile.bpfman-operator.openshift
-  - name: hermetic
-    value: 'true'
   - name: path-context
     value: .
   - name: build-platforms

--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -33,8 +33,6 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator:{{revision}}
   - name: dockerfile
     value: Containerfile.bpfman-operator.openshift
-  - name: hermetic
-    value: 'true'
   - name: path-context
     value: .
   - name: build-platforms


### PR DESCRIPTION
This reverts commit 5b76489d8e8823fe05afbce37a62c77f2a97b13c.

The change 5b76489d8e8823fe05afbce37a62c77f2a97b13c meant that the konflux jobs stopped running. 

Revert this change whilst we work out why the release of the bpfman-operator "application" fails. This is clearly the wrong change.