### PR TITLE
Disable profiling port in bpfman-agent to avoid host network conflicts

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -435,7 +435,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: 'true'
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -350,7 +350,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -116,7 +116,7 @@ spec:
           command: [/bpfman-agent]
           args:
             - --health-probe-bind-address=:8175
-            - --profiling-bind-address=:6060
+            # - --profiling-bind-address=:6060
           image: quay.io/bpfman/bpfman-agent:latest
           securityContext:
             privileged: true


### PR DESCRIPTION
Cherry-picked from upstream commit 9bb7c45f.

Disable the profiling port (6060) in bpfman-agent to prevent host network conflicts.

The bpfman-agent runs with `hostNetwork=true`, which causes port 6060 to be bound on every node. There's currently no configuration option to disable or change this port. This change comments out the hardcoded profiling argument to allow production deployments to proceed without port conflicts.

The profiling capability can be easily re-enabled in development environments if needed.