### PR TITLE
Revert PR #674: fix hermetic build defaults

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -435,7 +435,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: 'true'
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -350,7 +350,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string


### PR DESCRIPTION
This reverts the merge of PR #674 which changed hermetic build parameter defaults from 'false' to 'true' in Tekton pipelines.

## Reason for revert
The hermetic build defaults are preventing Konflux jobs from running on other PRs, causing CI pipeline failures.

## Evidence
- PR #676 had no Konflux jobs initially when hermetic defaults were 'true'
- After reverting hermetic changes on that branch, all Konflux jobs started running
- This indicates the hermetic defaults cause early pipeline termination

## Impact
Reverts changes to:
- `.tekton/multi-arch-build-pipeline.yaml` - hermetic default: 'true' → 'false'
- `.tekton/single-arch-build-pipeline.yaml` - hermetic default: "true" → "false"

This will restore normal Konflux job execution whilst we investigate alternative solutions for the `hermetic_task.hermetic` policy violations.