### PR TITLE
Revert hermetic build configuration changes

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -435,7 +435,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "true"
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string

--- a/.tekton/ocp-bpfman-agent-pull-request.yaml
+++ b/.tekton/ocp-bpfman-agent-pull-request.yaml
@@ -43,8 +43,6 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-  - name: hermetic
-    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-agent-push.yaml
+++ b/.tekton/ocp-bpfman-agent-push.yaml
@@ -41,8 +41,6 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-  - name: hermetic
-    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile.bundle.openshift
-  - name: hermetic
-    value: "true"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -32,8 +32,6 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-bundle:{{revision}}
   - name: dockerfile
     value: Containerfile.bundle.openshift
-  - name: hermetic
-    value: "true"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -31,6 +31,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -31,6 +31,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-pull-request.yaml
@@ -95,7 +95,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: 'true'
+    - default: 'false'
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -213,7 +213,7 @@ spec:
       - name: CONTEXT
         value: $(params.path-context)
       - name: HERMETIC
-        value: $(params.hermetic)
+        value: 'true'
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
       - name: COMMIT_SHA

--- a/.tekton/ocp-bpfman-operator-catalog-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-push.yaml
@@ -92,7 +92,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: 'true'
+    - default: 'false'
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -210,7 +210,7 @@ spec:
       - name: CONTEXT
         value: $(params.path-context)
       - name: HERMETIC
-        value: $(params.hermetic)
+        value: 'true'
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
       - name: COMMIT_SHA

--- a/.tekton/ocp-bpfman-operator-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-pull-request.yaml
@@ -43,8 +43,6 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-  - name: hermetic
-    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -41,8 +41,6 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-  - name: hermetic
-    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -63,6 +63,8 @@ spec:
       params:
       - name: input
         value: "$(params.prefetch-input)"
+      - name: hermetic
+        value: "$(params.hermetic)"
       - name: dev-package-managers
         value: $(params.prefetch-dev-package-managers-enabled)
       - name: SOURCE_ARTIFACT

--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -116,7 +116,7 @@ spec:
           command: [/bpfman-agent]
           args:
             - --health-probe-bind-address=:8175
-            - --profiling-bind-address=:6060
+            # - --profiling-bind-address=:6060
           image: quay.io/bpfman/bpfman-agent:latest
           securityContext:
             privileged: true


### PR DESCRIPTION
Reverts commit 67603b20 that fixed Konflux hermetic build configuration.

## Summary
- Reverts the hermetic build parameter changes that were causing Konflux pipeline issues
- Returns to the previous pipeline configuration to restore build functionality

## Context
The hermetic build configuration changes were preventing Konflux pipelines from triggering correctly, causing build failures across the project.