### PR TITLE
Fix test-fmt job by updating CI build root to use Go 1.23

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,5 +1,5 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19
 


### PR DESCRIPTION
## Summary
Fixes the failing test-fmt job by updating the CI build root image to use Go 1.23 instead of Go 1.22.

## Problem
The test-fmt job was failing with the error:
```
go: go.mod requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)
make: *** [Makefile:279: fmt] Error 1
```

This occurred because:
- The project's `go.mod` requires Go 1.23.0 
- The CI build root image was using `rhel-9-release-golang-1.22-openshift-4.18`
- The version mismatch caused the `make fmt` command to fail

## Solution
Updated `.ci-operator.yaml` to use `rhel-9-release-golang-1.23-openshift-4.19` build root image.

## Test plan
- [x] Verify the change fixes the Go version mismatch
- [ ] Test that test-fmt job passes with the new build root
- [ ] Ensure all other CI jobs continue to work

This addresses the underlying issue identified in PR #678.