### PR TITLE
Fix hermetic builds: resolve pipelineRef parameter validation issue

### DIFF
--- a/.tekton/ocp-bpfman-agent-pull-request.yaml
+++ b/.tekton/ocp-bpfman-agent-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: hermetic
+    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-agent-push.yaml
+++ b/.tekton/ocp-bpfman-agent-push.yaml
@@ -41,6 +41,8 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: hermetic
+    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile.bundle.openshift
+  - name: hermetic
+    value: "true"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -32,6 +32,8 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-bundle:{{revision}}
   - name: dockerfile
     value: Containerfile.bundle.openshift
+  - name: hermetic
+    value: "true"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: hermetic
+    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -41,6 +41,8 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: hermetic
+    value: "true"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Summary

This PR fixes the hermetic build configuration issue that was previously attempted in PR #681 and reverted in PR #689 due to Konflux jobs failing to launch.

### Key Changes

- Add explicit `hermetic: "true"` parameter to all PipelineRun files that use `pipelineRef`
- Enables hermetic builds while ensuring proper Tekton parameter validation
- Fixes the root cause that prevented Konflux jobs from launching

### Root Cause Analysis

The previous failure occurred because of a fundamental difference in how Tekton handles parameters between:

1. **pipelineRef** (external pipeline reference): Requires explicit parameter passing in PipelineRun spec.params
2. **pipelineSpec** (inline pipeline definition): Can define defaults directly in pipelineSpec.params

Our catalogue builds (4.19, 4.20, etc.) work because they use `pipelineSpec` with inline definitions. Our operator/agent builds failed because they use `pipelineRef` but weren't passing the required `hermetic` parameter.

### Technical Details

**Working Pattern (Catalog Builds):**
```yaml
spec:
  params:
    - name: hermetic
      value: 'true'        # Explicit value
  pipelineSpec:            # Inline definition
    params:
      - default: 'true'    # Can set default
        name: hermetic
```

**Broken Pattern (Fixed by this PR):**
```yaml
spec:
  params:
    # Missing hermetic parameter\! 
  pipelineRef:
    name: build-pipeline   # External reference expects parameter
```

### Files Modified

- `ocp-bpfman-agent-pull-request.yaml`: Added hermetic: "true" parameter
- `ocp-bpfman-agent-push.yaml`: Added hermetic: "true" parameter  
- `ocp-bpfman-operator-pull-request.yaml`: Added hermetic: "true" parameter
- `ocp-bpfman-operator-push.yaml`: Added hermetic: "true" parameter
- `ocp-bpfman-operator-bundle-pull-request.yaml`: Added hermetic: "true" parameter
- `ocp-bpfman-operator-bundle-push.yaml`: Added hermetic: "true" parameter

## Test plan

- [x] YAML syntax validation passes
- [ ] Verify Konflux jobs can launch successfully
- [ ] Confirm hermetic builds are enabled
- [ ] Test that PR builds work without breaking subsequent PRs