### PR TITLE
Complete hermetic-by-default build architecture

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -435,7 +435,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: 'false'
+  - default: 'true'
     description: Execute the build with network isolation
     name: hermetic
     type: string

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
-  - name: hermetic
-    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
-  - name: hermetic
-    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
-  - name: hermetic
-    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
-  - name: hermetic
-    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -350,7 +350,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string


### PR DESCRIPTION
## Summary

This PR implements the complete hermetic-by-default build architecture starting from a clean baseline (downstream/main), demonstrating the cleanest possible approach to secure builds without any prior hermetic fixes.

### Architectural Vision

This PR shows what the hermetic build system should look like from first principles:
- **Set defaults once** at the pipeline level
- **Inherit everywhere** through clean architecture
- **Eliminate redundancy** by removing unnecessary explicit configuration

### Changes Made

#### 1. Pipeline Defaults Updated (2 files)
- `.tekton/multi-arch-build-pipeline.yaml`: `default: 'false'` → `default: 'true'`
- `.tekton/single-arch-build-pipeline.yaml`: `default: "false"` → `default: "true"`

#### 2. Catalogue Configuration Cleaned (4 files)
Removed redundant `hermetic: 'true'` input parameters from:
- `.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml`
- `.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml`
- `.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml`
- `.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml`

These files now rely on their internal `pipelineSpec.params` defaults.

### Impact

**PipelineRef Files (Automatic Inheritance):**
All files using `pipelineRef` now automatically inherit `hermetic: 'true'`:
- `ocp-bpfman-operator-pull-request.yaml` ✅ Hermetic by inheritance
- `ocp-bpfman-operator-push.yaml` ✅ Hermetic by inheritance
- `ocp-bpfman-agent-pull-request.yaml` ✅ Hermetic by inheritance
- `ocp-bpfman-agent-push.yaml` ✅ Hermetic by inheritance
- `ocp-bpfman-operator-bundle-pull-request.yaml` ✅ Hermetic by inheritance
- `ocp-bpfman-operator-bundle-push.yaml` ✅ Hermetic by inheritance

**Catalogue Files (Internal Defaults):**
- 4.19 and 4.20 catalogue files: Now use internal `pipelineSpec` defaults
- 4.18 and base catalogue files: Already clean (no input parameters)

### Architecture Comparison

This PR provides a clean alternative to PR #694's explicit parameter approach:

**PR #694 (Explicit Parameters):**
```yaml
# Repeated everywhere
spec:
  params:
    - name: hermetic
      value: "true"  # ← Explicit in every file
```

**This PR (Clean Inheritance):**
```yaml
# Clean, no repetition
spec:
  params:
    # No hermetic parameter needed\!
  pipelineRef:
    name: build-pipeline  # ← Inherits 'true' default
```

### Benefits

- ✅ **Secure by default**: All builds hermetic without explicit configuration
- ✅ **DRY principle**: Configuration set once, inherited everywhere
- ✅ **Maintainable**: New pipelines automatically secure
- ✅ **Clean codebase**: 6 files changed, 2 insertions(+), 10 deletions(-)
- ✅ **True defaults**: Hermetic behaviour is actually default, not just explicit

### Test Plan

- [x] YAML syntax validation passes
- [ ] Verify all pipelineRef files inherit hermetic: 'true' default
- [ ] Confirm catalogue files work with cleaned configuration
- [ ] Test that builds are actually hermetic (network isolation)
- [ ] Ensure new pipelines automatically inherit secure behaviour

### Related PRs

- **PR #694**: Explicit parameters approach (ready to merge)
- **PR #695**: Incremental improvement (pipeline defaults only)
- **This PR**: Complete clean architecture from scratch

This provides three options with different approaches and risk levels for implementing hermetic builds.