### PR TITLE
Fix fbc-fips-check-oci-ta task failure by ensuring comprehensive upstream image replacement

### DIFF
--- a/hack/update_bundle.sh
+++ b/hack/update_bundle.sh
@@ -7,6 +7,7 @@ export BPFMAN_OPERATOR_IMAGE_PULLSPEC="registry.redhat.io/bpfman/bpfman-rhel9-op
 
 export CSV_FILE=/manifests/bpfman-operator.clusterserviceversion.yaml
 
+# Update CSV file
 sed -i -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
        -e "s|quay.io/bpfman/bpfman-operator:latest*|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
        -e "s|displayName: Bpfman Operator|displayName: eBPF Manager Operator|g" \
@@ -14,6 +15,12 @@ sed -i -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSP
        -e "s|name: The bpfman Community|name: Red Hat|g" \
        -e "s|url: https://bpfman.io|url: https://www.redhat.com|g" \
 	     "${CSV_FILE}"
+
+# Also update any other manifest files that might contain upstream references
+find /manifests -name "*.yaml" -exec sed -i \
+    -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
+    -e "s|quay.io/bpfman/bpfman-operator:latest|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
+    {} \;
 
 export AMD64_BUILT=$(skopeo inspect --raw docker://${BPFMAN_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="amd64")')
 export ARM64_BUILT=$(skopeo inspect --raw docker://${BPFMAN_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="arm64")')


### PR DESCRIPTION
## Problem

The `fbc-fips-check-oci-ta` task is failing during enterprise contract validation with this error:

```
Error: Unable to scan image: Could not get com.redhat.component label for quay.io/bpfman/bpfman-operator:latest
```

**Full task log:**
```
step-fips-operator-check-step-action :-
Related images are :
quay.io/bpfman/bpfman-operator:latest

Target OCP version found: -V=4.19
Image Mirror Map found:
{
  "registry.redhat.io/bpfman/bpfman-agent": [
    "quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-agent"
  ],
  "registry.redhat.io/bpfman/bpfman-operator-bundle": [
    "quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-bundle"
  ],
  "registry.redhat.io/bpfman/bpfman-rhel9-operator": [
    "quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator"
  ],
  "registry.redhat.io/bpfman/bpfman": [
    "quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman"
  ]
}
Processing related image 1 of 1: quay.io/bpfman/bpfman-operator:latest
Successfully inspected quay.io/bpfman/bpfman-operator:latest. Mirror not required.
Component label is 
Version label is 42
Release label is 
Error: Unable to scan image: Could not get com.redhat.component label for quay.io/bpfman/bpfman-operator:latest
```

## Root Cause

The FIPS compliance checker found upstream `quay.io/bpfman/bpfman-operator:latest` image references in processed bundles. These upstream images lack the required `com.redhat.component` labels that Red Hat enterprise contract validation expects.

The issue occurs because `hack/update_bundle.sh` only processed the main CSV file but missed other manifest files that might contain upstream image references. The FIPS checker examines all manifest content and found untransformed upstream references.

## Solution

Enhanced `hack/update_bundle.sh` to process ALL YAML files in the `/manifests` directory as a safety net, ensuring every upstream image reference gets replaced with the appropriate downstream `registry.redhat.io` image that includes proper Red Hat component labels.

**Changes:**
- Keep existing CSV-specific processing with display name and URL transformations
- Add comprehensive find/replace across all manifest YAML files
- Use precise patterns to avoid unintended replacements:
  - `quay.io/bpfman/bpfman-operator:v.*` (versioned tags)
  - `quay.io/bpfman/bpfman-operator:latest` (exact latest tag)

This maintains the generic nature of upstream configuration files whilst ensuring downstream builds pass enterprise contract validation requirements.

## Testing

After this fix, the FIPS checker should find only downstream `registry.redhat.io` images with proper Red Hat labels, resolving the enterprise contract validation failures.