### PR TITLE
Complete Tekton task updates missed by PR #655

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -238,7 +238,7 @@ spec:
       - name: name
         value: ecosystem-cert-preflight-checks
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:f99d2bdb02f13223d494077a2cde31418d09369f33c02134a8e7e5fad2f61eda
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:fd146c14794b6bc15384359d0dc8afc8a4a5f2b167503c6288ec2d86c8cbc9c0
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -188,7 +188,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:f99d2bdb02f13223d494077a2cde31418d09369f33c02134a8e7e5fad2f61eda
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:fd146c14794b6bc15384359d0dc8afc8a4a5f2b167503c6288ec2d86c8cbc9c0
         - name: kind
           value: task
       when:


### PR DESCRIPTION
## Summary
PR #655 updated some buildah tasks but missed `ecosystem-cert-preflight-checks`, which was causing Enterprise Contract validation failures in downstream releases.

## Changes
- Updated `task-ecosystem-cert-preflight-checks` SHA256 from `f99d2bdb02f13223...` to `fd146c14794b6bc15384359...`
- Applied the update to both multi-arch and single-arch build pipelines

## Fixes
- `test.no_failed_informative_tests` warnings in Enterprise Contract validation
- `CouldntGetTask` errors preventing successful builds
- `test.no_erred_tests` and related pipeline failures

## Background
The automated dependency update bot appears to have missed this task reference when it updated other Konflux Tekton tasks. This completes the incomplete updates from PR #655.

The new SHA256 hash corresponds to the latest trusted version as reported by Enterprise Contract validation logs.