### PR TITLE
Revert "Fix FIPS compliance check by ensuring comprehensive upstream image replacement in bundle processing"

### DIFF
--- a/hack/update_bundle.sh
+++ b/hack/update_bundle.sh
@@ -7,7 +7,6 @@ export BPFMAN_OPERATOR_IMAGE_PULLSPEC="registry.redhat.io/bpfman/bpfman-rhel9-op
 
 export CSV_FILE=/manifests/bpfman-operator.clusterserviceversion.yaml
 
-# Update CSV file
 sed -i -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
        -e "s|quay.io/bpfman/bpfman-operator:latest*|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
        -e "s|displayName: Bpfman Operator|displayName: eBPF Manager Operator|g" \
@@ -15,12 +14,6 @@ sed -i -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSP
        -e "s|name: The bpfman Community|name: Red Hat|g" \
        -e "s|url: https://bpfman.io|url: https://www.redhat.com|g" \
 	     "${CSV_FILE}"
-
-# Also update any other manifest files that might contain upstream references
-find /manifests -name "*.yaml" -exec sed -i \
-    -e "s|quay.io/bpfman/bpfman-operator:v.*|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
-    -e "s|quay.io/bpfman/bpfman-operator:latest|\"${BPFMAN_OPERATOR_IMAGE_PULLSPEC}\"|g" \
-    {} \;
 
 export AMD64_BUILT=$(skopeo inspect --raw docker://${BPFMAN_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="amd64")')
 export ARM64_BUILT=$(skopeo inspect --raw docker://${BPFMAN_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="arm64")')


### PR DESCRIPTION
## Summary

This reverts commit f9418c71 (PR #708) which added unnecessary manifest processing to `update_bundle.sh`.

## Background

The original commit was intended to fix FIPS compliance failures by processing all manifest YAML files, but this approach was unnecessary because:

1. **File-based catalog (FBC) format**: The catalog builds use `update_catalog.sh` which already properly handles all image reference updates through Python processing of `index.yaml`

2. **No separate manifest directory**: The `find /manifests -name "*.yaml"` command targets a directory structure that doesn't exist in FBC catalogs - everything is consolidated in `index.yaml`

3. **Related images already handled**: The catalog processing correctly updates both bundle images and related images (operator container images) to Red Hat enterprise registry with SHA256 digests

## Analysis

Local testing confirms that catalog builds work correctly without this additional processing:
- Bundle images are properly updated to Red Hat registry references
- Related images (operator container images) are correctly processed
- FIPS compliance requirements are met through the existing catalog processing

## What this revert does

- Removes the `find /manifests` command that was processing non-existent files
- Removes the associated sed replacements for upstream image references
- Keeps all the CSV-specific transformations that are still needed for bundle builds
- Maintains the Python processing that handles architecture labels and annotations

This should resolve any confusion about where image processing occurs and eliminate redundant processing steps.

Reverts f9418c7146a16cdb6a2e2e35d4bad32057390629