### PR TITLE
Revert hermetic-by-default build architecture (seeking non-hermetic build exception)

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -435,7 +435,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: 'true'
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -31,6 +31,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.19
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -31,6 +31,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile.catalog.openshift-4.20
+  - name: hermetic
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -350,7 +350,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string


### PR DESCRIPTION
## Summary

This PR reverts PR #696 (hermetic-by-default build architecture) to restore non-hermetic build behaviour for the bpfman-operator project.

## Reasoning for Non-Hermetic Build Exception

We are seeking a **non-hermetic build exception** for openshift/bpfman due to the following technical constraints:

### 1. Rust Toolchain Requirements
- **Rust 1.85 with edition 2024** required for our eBPF implementation
- **RHEL 9.6 provides only older Rust versions** that lack necessary features
- Modern eBPF development requires cutting-edge Rust capabilities not available in enterprise repos

### 2. Cargo Dependency Patches
- We maintain **custom cargo/dependency patches** for eBPF library compatibility
- These patches **break hermetic build assumptions** about dependency resolution
- Network access required for dynamic dependency resolution with our patches

### 3. Build Environment Constraints
- Hermetic builds expect all dependencies to be pre-fetched and cached
- Our eBPF build process requires **dynamic compilation** of BPF bytecode
- Rust ecosystem dependencies change rapidly and cannot be easily pre-cached

## Changes Reverted

This revert restores the following build behaviour:

- ✅ **Pipeline defaults**: `hermetic: 'false'` in multi-arch and single-arch pipelines
- ✅ **Catalog configurations**: Explicit `hermetic: 'true'` parameters restored where needed
- ✅ **Network access**: Builds can access external resources during compilation
- ✅ **Dynamic dependencies**: Rust cargo can resolve and fetch dependencies as needed

## Files Modified

- `.tekton/multi-arch-build-pipeline.yaml`: hermetic default `'true'` → `'false'`
- `.tekton/single-arch-build-pipeline.yaml`: hermetic default `'true'` → `'false'`
- 4x catalog pipeline files: Restored explicit hermetic parameters

## Impact

This change allows the bpfman-operator to continue building successfully while we work towards:
1. **Upstream Rust support** in RHEL repositories
2. **Dependency patch integration** that's compatible with hermetic builds
3. **Long-term hermetic compliance** once toolchain constraints are resolved

## Related Issues

- Rust 1.85 + edition 2024 requirement for eBPF development
- Custom cargo patches for eBPF library compatibility
- RHEL 9.6 toolchain limitations

## Test Plan

- [x] Verify pipeline defaults are restored to non-hermetic
- [x] Confirm builds can access network resources
- [x] Test that Rust compilation works with dynamic dependencies
- [ ] Validate all catalog builds complete successfully

This is a **temporary exception** while we work towards hermetic build compatibility.

Reverts 0c3be923c450bf77fb44e7b102053fa47cc7718a