### PR TITLE
Fix registry authentication for catalogue builds

### DIFF
--- a/Containerfile.catalog.openshift-4.17
+++ b/Containerfile.catalog.openshift-4.17
@@ -13,7 +13,7 @@ RUN ./update_catalog.sh
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.17
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/Containerfile.catalog.openshift-4.18
+++ b/Containerfile.catalog.openshift-4.18
@@ -13,7 +13,7 @@ RUN ./update_catalog.sh
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/Containerfile.catalog.openshift-4.19
+++ b/Containerfile.catalog.openshift-4.19
@@ -13,7 +13,7 @@ RUN ./update_catalog.sh
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
## Summary

Resolves authentication failures in Konflux managed release pipelines by replacing `brew.registry.redhat.io` with `registry.redhat.io` for released OpenShift versions.

## Problem

The managed release pipelines are failing with authentication errors during the `fbc-fips-check-oci-ta` task:
- Task fails when trying to pull from `brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9`
- Pipeline error: "UNAUTHORISED: Please login to the Red Hat Registry using your Customer Portal credentials"

## Solution

**For released OpenShift versions (4.17-4.19):**
- Replace `brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9` with `registry.redhat.io/openshift4/ose-operator-registry-rhel9`
- These images are publicly accessible with existing Red Hat registry credentials

**For unreleased OpenShift versions (4.20):**
- Keep `brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9` 
- Image not yet available in public registry

## Changes

- `Containerfile.catalog.openshift-4.17` → Use `registry.redhat.io/openshift4`
- `Containerfile.catalog.openshift-4.18` → Use `registry.redhat.io/openshift4`  
- `Containerfile.catalog.openshift-4.19` → Use `registry.redhat.io/openshift4`
- `Containerfile.catalog.openshift-4.20` → Keep `brew.registry.redhat.io` (unreleased)

## Testing

Confirmed locally that released versions (v4.17-4.19) are available in `registry.redhat.io/openshift4` whilst v4.20 is not yet published.