### PR TITLE
Replace Python catalog processing with shell-based FIPS-compliant solution

### DIFF
--- a/Containerfile.catalog.openshift-4.17
+++ b/Containerfile.catalog.openshift-4.17
@@ -1,26 +1,18 @@
-FROM registry.access.redhat.com/ubi9/python-312 as builder-runner
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-# Use a new stage to enable caching of the package installations for local development
-FROM builder-runner as builder
-
-#Copy files to locations specified by labels.
-COPY --chown=default:root catalog /configs/bpfman-operator
-COPY hack/update_catalog.sh .
-COPY hack/patch_catalog_build_date.py hack/
-RUN ./update_catalog.sh
-
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
 
+# Copy files to final location and process in place
+COPY catalog /configs/bpfman-operator
+COPY hack/update_catalog.sh .
+
+# USER root required because base image runs as uid=1001 but we need write access to /configs
+USER root
+RUN ./update_catalog.sh && rm ./update_catalog.sh
+
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-COPY --from=builder /configs/bpfman-operator /configs/bpfman-operator
 
 RUN /bin/opm serve /configs --cache-dir=/tmp/cache --cache-only
 

--- a/Containerfile.catalog.openshift-4.18
+++ b/Containerfile.catalog.openshift-4.18
@@ -1,26 +1,18 @@
-FROM registry.access.redhat.com/ubi9/python-312 as builder-runner
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-# Use a new stage to enable caching of the package installations for local development
-FROM builder-runner as builder
-
-#Copy files to locations specified by labels.
-COPY --chown=default:root catalog /configs/bpfman-operator
-COPY hack/update_catalog.sh .
-COPY hack/patch_catalog_build_date.py hack/
-RUN ./update_catalog.sh
-
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
+# Copy files to final location and process in place
+COPY catalog /configs/bpfman-operator
+COPY hack/update_catalog.sh .
+
+# USER root required because base image runs as uid=1001 but we need write access to /configs
+USER root
+RUN ./update_catalog.sh && rm ./update_catalog.sh
+
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-COPY --from=builder /configs/bpfman-operator /configs/bpfman-operator
 
 RUN /bin/opm serve /configs --cache-dir=/tmp/cache --cache-only
 

--- a/Containerfile.catalog.openshift-4.19
+++ b/Containerfile.catalog.openshift-4.19
@@ -1,26 +1,18 @@
-FROM registry.access.redhat.com/ubi9/python-312 as builder-runner
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-# Use a new stage to enable caching of the package installations for local development
-FROM builder-runner as builder
-
-#Copy files to locations specified by labels.
-COPY --chown=default:root catalog /configs/bpfman-operator
-COPY hack/update_catalog.sh .
-COPY hack/patch_catalog_build_date.py hack/
-RUN ./update_catalog.sh
-
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
+# Copy files to final location and process in place
+COPY catalog /configs/bpfman-operator
+COPY hack/update_catalog.sh .
+
+# USER root required because base image runs as uid=1001 but we need write access to /configs
+USER root
+RUN ./update_catalog.sh && rm ./update_catalog.sh
+
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-COPY --from=builder /configs/bpfman-operator /configs/bpfman-operator
 
 RUN /bin/opm serve /configs --cache-dir=/tmp/cache --cache-only
 

--- a/Containerfile.catalog.openshift-4.20
+++ b/Containerfile.catalog.openshift-4.20
@@ -1,26 +1,18 @@
-FROM registry.access.redhat.com/ubi9/python-312 as builder-runner
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-# Use a new stage to enable caching of the package installations for local development
-FROM builder-runner as builder
-
-#Copy files to locations specified by labels.
-COPY --chown=default:root catalog /configs/bpfman-operator
-COPY hack/update_catalog.sh .
-COPY hack/patch_catalog_build_date.py hack/
-RUN ./update_catalog.sh
-
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
 
+# Copy files to final location and process in place
+COPY catalog /configs/bpfman-operator
+COPY hack/update_catalog.sh .
+
+# USER root required because base image runs as uid=1001 but we need write access to /configs
+USER root
+RUN ./update_catalog.sh && rm ./update_catalog.sh
+
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-COPY --from=builder /configs/bpfman-operator /configs/bpfman-operator
 
 RUN /bin/opm serve /configs --cache-dir=/tmp/cache --cache-only
 

--- a/hack/update_catalog.sh
+++ b/hack/update_catalog.sh
@@ -6,52 +6,27 @@ export BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC="registry.redhat.io/bpfman/bpfman-o
 #
 export BPFMAN_OPERATOR_IMAGE_PULLSPEC="registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:9f0ad08027cf867e14f9ff91b0f11484126314a110cf6d6057049bca6089b2b8"
 #
-# Copy catalog to writable location for processing
-cp -r /configs/bpfman-operator /tmp/
-export INDEX_FILE=/tmp/bpfman-operator/index.yaml
+export INDEX_FILE=/configs/bpfman-operator/index.yaml
 
-# Process catalog files directly
+echo "Catalog processing started"
+echo "Using bundle image: ${BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC}"
+echo "Using operator image: ${BPFMAN_OPERATOR_IMAGE_PULLSPEC}"
 
-# time for some direct modifications to the csv
-python3 - << INDEX_FILE_UPDATE
-import os
-from collections import OrderedDict
-from sys import exit as sys_exit
-from datetime import datetime
-from ruamel.yaml import YAML
-yaml = YAML()
-def load_manifest(pathn):
-   if not pathn.endswith(".yaml"):
-      return None
-   try:
-      with open(pathn, "r") as f:
-         return list(yaml.load_all(f))
-   except FileNotFoundError:
-      print("File can not found")
-      exit(2)
+echo "BEFORE processing:"
+echo "  Image fields:"
+grep -n "image:" "${INDEX_FILE}"
+echo "  CreatedAt field:"
+grep -n "createdAt:" "${INDEX_FILE}"
 
-def dump_manifest(pathn, manifest):
-   with open(pathn, "w") as f:
-      yaml.dump_all(manifest, f)
-   return
+sed -i -E \
+    -e "s|^(\s*-?\s*image:\s*)registry\.redhat\.io/bpfman/bpfman-operator-bundle@.*$|\1${BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC}|" \
+    -e "s|^(\s*containerImage:\s*)quay\.io/bpfman/bpfman-operator:latest$|\1${BPFMAN_OPERATOR_IMAGE_PULLSPEC}|" \
+    -e "s|^(\s*-?\s*image:\s*)quay\.io/bpfman/bpfman-operator:latest$|\1${BPFMAN_OPERATOR_IMAGE_PULLSPEC}|" \
+    -e "s|^(\s*createdAt:\s*)(.+)$|\1$(date +'%d %b %Y, %H:%M')|" \
+    "${INDEX_FILE}"
 
-manifest = load_manifest(os.getenv('INDEX_FILE'))
-
-if manifest is not None:
-    # Iterate over the loaded manifest and update the 'image' field
-    for index_file in manifest:
-        index_file['image'] = os.getenv('BPFMAN_OPERATOR_BUNDLE_IMAGE_PULLSPEC', '')
-    # Dump the updated manifest back into the file
-    dump_manifest(os.getenv('INDEX_FILE'), manifest)
-
-INDEX_FILE_UPDATE
-
-# Update catalog timestamp
-hack/patch_catalog_build_date.py "${INDEX_FILE}"
-
-echo "Catalog processing completed"
-
-# Copy processed catalog back to final location
-cp -r /tmp/bpfman-operator/* /configs/bpfman-operator/
-
-cat $INDEX_FILE
+echo "AFTER processing:"
+echo "  Image fields:"
+grep -n "image:" "${INDEX_FILE}"
+echo "  CreatedAt field:"
+grep -n "createdAt:" "${INDEX_FILE}"


### PR DESCRIPTION
This PR replaces Python-based catalog processing with shell-based sed operations to achieve FIPS compliance whilst maintaining compatibility with the nudging workflow.

**Key improvements:**
- Eliminates Python dependencies during catalog builds for FIPS compliance
- Maintains nudging workflow compatibility by preserving export variable structure
- Processes catalog files directly avoiding unnecessary file copying
- Adds comprehensive before/after logging for transparency
- Updates Containerfile comments to explain USER root requirement

**Technical implementation:**
- Uses sed with extended regex to replace image references in catalog YAML
- Replaces upstream quay.io/bpfman/bpfman-operator:latest with downstream SHA references
- Updates bundle image references to current nudged versions
- Updates createdAt timestamps to reflect processing time
- Maintains hermetic builds with no external network dependencies

**Testing validation:**
- Catalog builds successfully with shell processing
- OLM validation passes (opm serve completes without errors)
- All image references properly converted to downstream registry.redhat.io
- Before/after processing shows correct upstream to downstream migration

The solution respects the nudging workflow where hardcoded SHA values in export statements are updated by Konflux nudging PRs, ensuring the catalog processing remains in sync with current operator and bundle versions.