### PR TITLE
Fix Konflux nudging and bundle script synchronisation

### DIFF
--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: hack/update_bundle.sh, hack/update_catalog.sh
+    build.appstudio.openshift.io/build-nudge-files: hack/update_bundle.sh, hack/update_catalog.sh, hack/update_bundle_python.py
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/hack/update_bundle_python.py
+++ b/hack/update_bundle_python.py
@@ -7,39 +7,39 @@ yaml = YAML()
 
 # Configuration
 BPFMAN_OPERATOR_IMAGE_PULLSPEC = "registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84314fd013ffb523050fd1649c687b9a7a111030b5ecd9c048cacde0c851cc47"
+
 CSV_FILE = "/manifests/bpfman-operator.clusterserviceversion.yaml"
 
 def main():
     # Perform sed replacements on CSV file
     print("Updating CSV file...")
-    
+
     with open(CSV_FILE, 'r') as f:
         content = f.read()
-    
+
     # Apply sed-like replacements
     replacements = [
-        (r'quay.io/bpfman/bpfman-operator:v.*', f'"{BPFMAN_OPERATOR_IMAGE_PULLSPEC}"'),
-        (r'quay.io/bpfman/bpfman-operator:latest.*', f'"{BPFMAN_OPERATOR_IMAGE_PULLSPEC}"'),
+        ('quay.io/bpfman/bpfman-operator:latest', f'"{BPFMAN_OPERATOR_IMAGE_PULLSPEC}"'),
         ('displayName: Bpfman Operator', 'displayName: eBPF Manager Operator'),
         ('The bpfman Operator', 'The eBPF manager Operator'),
         ('name: The bpfman Community', 'name: Red Hat'),
         ('url: https://bpfman.io', 'url: https://www.redhat.com'),
     ]
-    
+
     for old, new in replacements:
         content = content.replace(old, new)
-    
+
     with open(CSV_FILE, 'w') as f:
         f.write(content)
-    
+
     # Load CSV for Python modifications
     with open(CSV_FILE, 'r') as f:
         bpfman_operator_csv = yaml.load(f)
-    
+
     # Set timestamp
     timestamp = int(datetime.now().timestamp())
     datetime_time = datetime.fromtimestamp(timestamp)
-    
+
     # Always add all architecture support labels (we build for all 4 architectures)
     if 'metadata' not in bpfman_operator_csv:
         bpfman_operator_csv['metadata'] = {}
@@ -47,14 +47,14 @@ def main():
         bpfman_operator_csv['metadata']['labels'] = {}
     if 'annotations' not in bpfman_operator_csv['metadata']:
         bpfman_operator_csv['metadata']['annotations'] = {}
-    
+
     # Add architecture support labels (always all 4 since we build for all)
     bpfman_operator_csv['metadata']['labels']['operatorframework.io/arch.amd64'] = 'supported'
     bpfman_operator_csv['metadata']['labels']['operatorframework.io/arch.arm64'] = 'supported'
     bpfman_operator_csv['metadata']['labels']['operatorframework.io/arch.ppc64le'] = 'supported'
     bpfman_operator_csv['metadata']['labels']['operatorframework.io/arch.s390x'] = 'supported'
     bpfman_operator_csv['metadata']['labels']['operatorframework.io/os.linux'] = 'supported'
-    
+
     # Add annotations
     bpfman_operator_csv['metadata']['annotations']['createdAt'] = datetime_time.strftime('%d %b %Y, %H:%M')
     bpfman_operator_csv['metadata']['annotations']['features.operators.openshift.io/disconnected'] = 'true'
@@ -64,11 +64,11 @@ def main():
     bpfman_operator_csv['metadata']['annotations']['features.operators.openshift.io/token-auth-aws'] = 'false'
     bpfman_operator_csv['metadata']['annotations']['features.operators.openshift.io/token-auth-azure'] = 'false'
     bpfman_operator_csv['metadata']['annotations']['features.operators.openshift.io/token-auth-gcp'] = 'false'
-    
+
     # Write back the modified CSV
     with open(CSV_FILE, 'w') as f:
         yaml.dump(bpfman_operator_csv, f)
-    
+
     print("CSV file updated successfully")
 
 if __name__ == "__main__":

--- a/hack/update_bundle_python.py
+++ b/hack/update_bundle_python.py
@@ -6,7 +6,7 @@ from ruamel.yaml import YAML
 yaml = YAML()
 
 # Configuration
-BPFMAN_OPERATOR_IMAGE_PULLSPEC = "registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:fd530e80207d584b02e1335a39571cdbfcd659dd9f164322dce02dcaff266ad2"
+BPFMAN_OPERATOR_IMAGE_PULLSPEC = "registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84314fd013ffb523050fd1649c687b9a7a111030b5ecd9c048cacde0c851cc47"
 CSV_FILE = "/manifests/bpfman-operator.clusterserviceversion.yaml"
 
 def main():


### PR DESCRIPTION
## Summary

Fix Konflux component update automation to keep both bundle scripts synchronised with the latest operator images, and resolve a critical bug in the Python bundle script that prevented operator image replacements.

## Problem

The bundle build process uses two scripts to patch CSV files with downstream operator images:
- `hack/update_bundle.sh` (used by shell-based builds)  
- `hack/update_bundle_python.py` (used by `Containerfile.bundle.openshift`)

However, Konflux component updates were only nudging `update_bundle.sh`, causing the scripts to drift badly out of sync:

- `hack/update_bundle.sh`: `sha256:84314fd013ff` (30 July 2025, current)
- `hack/update_bundle_python.py`: `sha256:fd530e80207d` (so old it no longer exists in registry)

Additionally, the Python script had a critical bug where it used regex patterns with literal string replacement, causing operator image replacements to fail silently.

## Impact

- Bundle builds referenced non-existent operator images  
- Bundles contained upstream `quay.io/bpfman/bpfman-operator:latest` instead of downstream `registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:...`
- Inconsistent operator image references across different build paths

## Solution

### 1. Fix Konflux Automation
Add `hack/update_bundle_python.py` to the `build-nudge-files` list in `.tekton/ocp-bpfman-operator-push.yaml` so both scripts get updated together when new operator builds are detected.

### 2. Sync Current Scripts  
Update Python script with the same current operator image SHA as the shell script.

### 3. Fix String Replacement Bug
Replace regex patterns with literal strings in the Python script:
```python
# Before (broken - regex patterns with literal replacement)
(r'quay.io/bpfman/bpfman-operator:v.*', f'"{BPFMAN_OPERATOR_IMAGE_PULLSPEC}"'),
(r'quay.io/bpfman/bpfman-operator:latest.*', f'"{BPFMAN_OPERATOR_IMAGE_PULLSPEC}"'),

# After (fixed - literal string matching)  
('quay.io/bpfman/bpfman-operator:latest', f'"{BPFMAN_OPERATOR_IMAGE_PULLSPEC}"'),
```

## Testing

Verified with local bundle build - the Python script now correctly replaces:
```
quay.io/bpfman/bpfman-operator:latest
→ registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84314fd013ff
```

## Result

- ✅ Future Konflux nudges will keep both scripts synchronised
- ✅ Bundle builds now reference current, existing operator images  
- ✅ Downstream bundles contain proper `registry.redhat.io` operator references
- ✅ Consistent operator images across all build paths