### PR TITLE
Skip fbc-target-index-pruning-check task in OCP 4.19 catalog pipelines

### DIFF
--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -391,7 +391,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.skip-checks)
+      - input: "true"
         operator: in
         values:
         - 'false'

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -388,7 +388,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.skip-checks)
+      - input: "true"
         operator: in
         values:
         - 'false'


### PR DESCRIPTION
## Summary

Skip the fbc-target-index-pruning-check task in OCP 4.19 catalog pipelines.

## Problem

The fbc-target-index-pruning-check task fails because our catalog generation process doesn't manage multiple releases/versions properly. Since BPFman is in Tech Preview, our catalog contains only the current release, effectively pruning all previous versions from the target index (registry.redhat.io/redhat/redhat-operator-index). 

This triggers validation failures as the task detects entire channels being removed from the catalog.

## Solution

As a Tech Preview project, this catalog pruning behaviour is acceptable. Modified the when condition to always skip this validation task for OCP 4.19 catalog builds while preserving all other validation tasks (validate-fbc, fbc-fips-check-oci-ta, etc.).

## Files Changed

- .tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml: Skip pruning check for push builds
- .tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml: Skip pruning check for PR builds

This allows the catalog build and FBC release pipeline to proceed successfully.