### PR TITLE
Fix missing metrics-proxy-daemonset.yaml in OpenShift Containerfile

### DIFF
--- a/Containerfile.bpfman-operator.openshift
+++ b/Containerfile.bpfman-operator.openshift
@@ -33,6 +33,7 @@ ARG TARGETPLATFORM
 WORKDIR /
 COPY --from=bpfman-operator-build /usr/src/bpfman-operator/config/bpfman-deployment/daemonset.yaml ./config/bpfman-deployment/daemonset.yaml
 COPY --from=bpfman-operator-build /usr/src/bpfman-operator/config/bpfman-deployment/csidriverinfo.yaml ./config/bpfman-deployment/csidriverinfo.yaml
+COPY --from=bpfman-operator-build /usr/src/bpfman-operator/config/bpfman-deployment/metrics-proxy-daemonset.yaml ./config/bpfman-deployment/metrics-proxy-daemonset.yaml
 COPY --from=bpfman-operator-build /usr/src/bpfman-operator/config/openshift/restricted-scc.yaml ./config/openshift/restricted-scc.yaml
 COPY --from=bpfman-operator-build /usr/src/bpfman-operator/bpfman-operator .
 COPY LICENSE /licenses/


### PR DESCRIPTION
## Problem

BPFman operator panics on OpenShift when deployed via OperatorHub. The controller crashes trying to load `./config/bpfman-deployment/metrics-proxy-daemonset.yaml` which doesn't exist in the container.

## Cause

When metrics proxy support was added in 63cde58a, the regular Containerfile was updated to copy the new config file but the OpenShift-specific Containerfile was missed. This means:

- Upstream builds work fine
- OpenShift builds are missing the file
- Runtime panic when controller tries to load it

## Fix

Add the missing COPY line to the OpenShift Containerfile to match what's already in the regular one.