### PR TITLE
URGENT: Stop 4.19 builds triggering from main branch

### DIFF
--- a/.tekton/ocp-bpfman-agent-pull-request.yaml
+++ b/.tekton/ocp-bpfman-agent-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
+      == "release-4.19" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-agent-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()

--- a/.tekton/ocp-bpfman-agent-push.yaml
+++ b/.tekton/ocp-bpfman-agent-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
+      == "release-4.19" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-agent-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()

--- a/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
+      == "release-4.19" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/***".pathChanged() || "config/***".pathChanged())
   creationTimestamp: null

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"  && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
+      == "release-4.19"  && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/update_bundle.sh".pathChanged() || "hack/update_configmap.sh".pathChanged() || "config/***".pathChanged())
   creationTimestamp: null

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-20

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-20

--- a/.tekton/ocp-bpfman-operator-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
+      == "release-4.19" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-operator-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()

--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
+      == "release-4.19" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-operator-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()


### PR DESCRIPTION
Emergency fix to prevent race condition where main branch changes trigger 4.19 builds. Updates all pipeline files to only trigger on release-4.19 branch changes.