### PR TITLE
Add requirements.txt to Tekton pipeline CEL expressions

### DIFF
--- a/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
@@ -10,7 +10,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
-      || "bundle/***".pathChanged() || "hack/***".pathChanged() || "config/***".pathChanged())
+      || "bundle/***".pathChanged() || "hack/***".pathChanged() || "config/***".pathChanged()
+      || "requirements.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -10,7 +10,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"  && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
       || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
-      || "bundle/***".pathChanged() || "hack/update_bundle.sh".pathChanged() || "hack/update_configmap.sh".pathChanged() || "config/***".pathChanged())
+      || "bundle/***".pathChanged() || "hack/update_bundle.sh".pathChanged() || "hack/update_configmap.sh".pathChanged() || "config/***".pathChanged()
+      || "requirements.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.18" && (".tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.18".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.18" && (".tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.18".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-18

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-18-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-18-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.18" && (".tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-18-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.18".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.18" && (".tekton/ocp-bpfman-operator-catalog-ocp4-18-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-18-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.18".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-18

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-20

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-20-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-20-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.20".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-20

--- a/.tekton/ocp-bpfman-operator-catalog-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.17" && (".tekton/ocp-bpfman-operator-catalog-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.17".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.17" && (".tekton/ocp-bpfman-operator-catalog-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.17".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-17

--- a/.tekton/ocp-bpfman-operator-catalog-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.17" && ( ".tekton/ocp-bpfman-operator-catalog-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.17".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.17" && ( ".tekton/ocp-bpfman-operator-catalog-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.17".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-17


### PR DESCRIPTION
## Summary
- Add `requirements.txt` to pathChanged() conditions in Tekton pipeline CEL expressions
- Fixes "No PipelineRun matched" issue for PRs that only update Python dependencies
- Aligns with pattern used by network-observability-operator

## Modified pipelines
- Bundle pipelines (pull-request and push)
- All catalog pipelines for OCP 4.17, 4.18, 4.19, and 4.20

## Test plan
- [ ] Verify CEL expressions are syntactically valid
- [ ] Test that pipelines trigger for requirements.txt changes
- [ ] Confirm existing pipeline triggers still work

This change ensures that PRs like #794 (dependency updates) will properly trigger the relevant build pipelines.