### PR TITLE
Enhance renovate configuration to group Python dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,19 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+  ],
+  "labels": ["dependencies"],
   "gomod": {
     "enabled": false
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["pip_requirements"],
+      "groupName": "Python dependencies",
+      "schedule": [
+        "after 5am on saturday"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Extend the konflux-ci/mintmaker base renovate configuration
- Group Python dependencies into single PRs instead of individual updates
- Schedule updates for Saturday mornings
- Add proper dependency labelling

## Problem
Currently, each Python dependency update creates a separate PR, leading to multiple individual PRs for `requirements.txt` changes (as seen with PRs #794-800). This creates unnecessary noise and review overhead.

## Solution
Enhanced `renovate.json` configuration that:
- Uses the standard mintmaker base configuration for consistency
- Groups all Python dependency updates (`pip_requirements` manager) into a single "Python dependencies" PR
- Schedules updates weekly on Saturday mornings
- Applies proper labelling for dependency PRs

## Benefits
- **Reduces PR noise**: Multiple Python package updates will be batched into one PR
- **Easier review process**: Single PR to review instead of 7+ individual PRs
- **Consistent with other projects**: Matches pattern used by network-observability-operator for Go modules
- **Better scheduling**: Weekly updates instead of ad-hoc individual updates

## Test plan
- [ ] Wait for next renovate run to verify Python dependencies are grouped
- [ ] Confirm individual Python dependency PRs are no longer created
- [ ] Verify proper labelling is applied

This change should significantly reduce the dependency update noise whilst maintaining proper dependency management.