### PR TITLE
Test verified label requirement after tide configuration changes

### DIFF
--- a/cmd/bpfman-operator/main.go
+++ b/cmd/bpfman-operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -85,6 +86,7 @@ func isOpenshift(client discovery.DiscoveryInterface, _ *rest.Config) (bool, err
 }
 
 func main() {
+	fmt.Println("hello world")
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string


### PR DESCRIPTION
## Purpose

This PR tests whether the verified label is still required for merging after the tide configuration changes made in the openshift/release repository.

## Changes

- Added debug print statement to main function to force rebuild
- This is purely a test PR to validate the current tide configuration

## Context

- Related to https://github.com/openshift/bpfman/pull/260 which is stuck waiting for verified label
- Testing the effectiveness of previous fixes in openshift/release PRs https://github.com/openshift/release/pull/68871 and https://github.com/openshift/release/pull/68881
- If this PR also gets stuck waiting for verified label, it confirms the configuration fix was incomplete

This PR should be closed after testing is complete.