### PR TITLE
Fix 4.19 catalog pipelines to target release-4.19 branch

### DIFF
--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged() || "requirements.txt".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "rpms.in.yaml".pathChanged() || "catalog/***".pathChanged() || "config/***".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19

--- a/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
+++ b/.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged() || "requirements.txt".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.19" && (".tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml".pathChanged() || "Containerfile.catalog.openshift-4.19".pathChanged() || "catalog/***".pathChanged() || "rpms.in.yaml".pathChanged() || "hack/update_catalog.sh".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: fbc-4-19


### PR DESCRIPTION
## Summary

This PR fixes the OpenShift 4.19 catalog build pipelines to target the `release-4.19` branch instead of `main`.

**Problem**: Both 4.19 and 4.20 catalog pipelines were configured to trigger on PRs targeting the `main` branch, causing both builds to run unnecessarily for every main branch PR.

**Solution**: Update the CEL expressions in both 4.19 catalog pipeline files to target `release-4.19` instead of `main`:

- `.tekton/ocp-bpfman-operator-catalog-ocp4-19-pull-request.yaml`
- `.tekton/ocp-bpfman-operator-catalog-ocp4-19-push.yaml`

**Branch alignment after this change**:
- 4.17 catalog builds: `release-4.17` branch
- 4.18 catalog builds: `release-4.18` branch  
- 4.19 catalog builds: `release-4.19` branch ← **Fixed**
- 4.20 catalog builds: `main` branch

This ensures proper separation of OpenShift release-specific builds and prevents unnecessary pipeline executions.

## Test plan

- [x] Verified CEL expression syntax is correct
- [x] Confirmed alignment with existing pattern used by 4.17 and 4.18 pipelines
- [ ] Validate that 4.19 catalog builds no longer trigger on main branch PRs
- [ ] Validate that 4.19 catalog builds properly trigger on release-4.19 branch PRs