### PR TITLE
Update builder images to Go 1.24 on RHEL 9

### DIFF
--- a/Containerfile.bpfman-agent.openshift
+++ b/Containerfile.bpfman-agent.openshift
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 AS bpfman-agent-build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS bpfman-agent-build
 
 # The following ARGs are set internally by docker/build-push-action in github actions
 ARG TARGETOS

--- a/Containerfile.bpfman-operator.openshift
+++ b/Containerfile.bpfman-operator.openshift
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 AS bpfman-operator-build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS bpfman-operator-build
 
 ARG BUILDPLATFORM
 


### PR DESCRIPTION
This PR updates the builder images used in the bpfman-agent and bpfman-operator Containerfiles.

## Changes

**From:** 
- `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23` (RHEL 8 based)

**To:**
- `registry.access.redhat.com/ubi9/go-toolset:1.24` (UBI9 based)

## Key Updates

- **Go version**: 1.23 → 1.24
- **Base image**: RHEL 8 → UBI9 (Universal Base Image)

## Affected Files
- `Containerfile.bpfman-agent.openshift`
- `Containerfile.bpfman-operator.openshift`