### PR TITLE
Test minimal CI configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
+# Testing minimal CI configuration
 ifeq ($(origin VERSION), undefined)
   VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0-unknown")
 endif


### PR DESCRIPTION
## Summary

This PR tests the simplified CI configuration following the merge of https://github.com/openshift/release/pull/69390.

## Purpose

Verify that:
- The test-fmt job runs correctly as our minimal CI gate
- Konflux build pipelines are triggered by the Makefile change
- No redundant CI jobs are attempting to run

This is a test PR that can be closed once we confirm everything works as expected.