### PR TITLE
Migrate build configuration from ocp-bpfman to ystream components

### DIFF
--- a/.tekton/bpfman-agent-ystream-pull-request.yaml
+++ b/.tekton/bpfman-agent-ystream-pull-request.yaml
@@ -9,7 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-agent-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-agent-ystream-push.yaml".pathChanged() || "apis/***".pathChanged()
+      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "vendor/***".pathChanged() || "config/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -8,7 +8,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-agent-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-agent-ystream-push.yaml".pathChanged() || "apis/***".pathChanged()
+      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -9,7 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
+      || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt, hack/konflux/images/bpfman-agent.txt, hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -8,7 +8,10 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
+      || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-ystream-pull-request.yaml
@@ -9,7 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-operator-ystream-push.yaml".pathChanged() || "apis/***".pathChanged()
+      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "vendor/***".pathChanged() || "config/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: ""
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -8,7 +8,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-operator-ystream-push.yaml".pathChanged() || "apis/***".pathChanged()
+      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream


### PR DESCRIPTION
## Summary

This PR migrates essential build configuration from the existing ocp-bpfman components to the new ystream components. The bpfman and bpfman-operator applications are being consolidated under a single application called bpfman-ystream.

## Changes

### 1. CEL Expression Migration
- Added pathChanged conditions to all ystream Tekton files
- Prevents unnecessary builds when unrelated files change
- Only triggers builds when relevant source files, configuration, or Containerfiles are modified
- Updated .tekton file references to point to ystream variants

### 2. Build Nudge Files Migration  
- Added build-nudge-files annotations to ystream push pipelines
- Ensures changes to base image files trigger appropriate rebuilds
- Maintains the same rebuild behaviour as existing components

## Testing
The ystream components should now trigger builds with the same logic as the existing ocp-bpfman components, avoiding unnecessary builds whilst ensuring all relevant changes trigger rebuilds.

## Future Work
A follow-up PR will migrate the ystream components to use pipeline references instead of inline pipeline specifications, maintaining consistency with the existing pattern.