### PR TITLE
Disable legacy ocp pipelines

### DIFF
--- a/.tekton/ocp-bpfman-agent-pull-request.yaml
+++ b/.tekton/ocp-bpfman-agent-pull-request.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
-      || ".tekton/ocp-bpfman-agent-push.yaml".pathChanged() || "apis/***".pathChanged()
-      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
-      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-agent-push.yaml
+++ b/.tekton/ocp-bpfman-agent-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
-      || ".tekton/ocp-bpfman-agent-push.yaml".pathChanged() || "apis/***".pathChanged()
-      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
-      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-pull-request.yaml
@@ -7,11 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
-      || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
-      || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -7,11 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"  && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
-      || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
-      || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-pull-request.yaml
+++ b/.tekton/ocp-bpfman-operator-pull-request.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
-      || ".tekton/ocp-bpfman-operator-push.yaml".pathChanged() || "apis/***".pathChanged()
-      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
-      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
-      || ".tekton/ocp-bpfman-operator-push.yaml".pathChanged() || "apis/***".pathChanged()
-      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
-      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator


### PR DESCRIPTION
## Summary

Disable PipelinesAsCode triggers for legacy ocp-* components by setting their CEL expressions to `"false"`.

## Background

Similar to https://github.com/openshift/bpfman/pull/274, we discovered that disabling components with the `mintmaker.appstudio.redhat.com/disabled` annotation only prevents Mintmaker from creating PRs, but doesn't stop PipelinesAsCode from triggering builds.

To fully disable these pipelines during the transition to ystream components, we need to set the CEL expressions to false.

## Changes

Set `pipelinesascode.tekton.dev/on-cel-expression: "false"` for all ocp-* pipeline files:
- `.tekton/ocp-bpfman-agent-pull-request.yaml`
- `.tekton/ocp-bpfman-agent-push.yaml`
- `.tekton/ocp-bpfman-operator-pull-request.yaml`
- `.tekton/ocp-bpfman-operator-push.yaml`
- `.tekton/ocp-bpfman-operator-bundle-pull-request.yaml`
- `.tekton/ocp-bpfman-operator-bundle-push.yaml`

## Result

After this change, only ystream pipelines will run. The legacy ocp-* pipelines will not be triggered.

Once we're satisfied with the ystream transition, we will delete these legacy pipeline files entirely.

## Related PRs

- **Test PR that discovered the issue**: https://github.com/openshift/bpfman/pull/273
- **Companion PR for bpfman**: https://github.com/openshift/bpfman/pull/274
- **Documentation about component management**: #878 (needs update to clarify mintmaker limitations)