### PR TITLE
Add ystream component mirrors to ImageDigestMirrorSet

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,14 +6,18 @@ spec:
   imageDigestMirrors:
     - source: registry.redhat.io/bpfman/bpfman-agent
       mirrors:
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-agent-ystream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-agent
     - source: registry.redhat.io/bpfman/bpfman-operator-bundle
       mirrors:
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-bundle
     - source: registry.redhat.io/bpfman/bpfman-rhel9-operator
       mirrors:
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-ystream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator
     - source: registry.redhat.io/bpfman/bpfman
       mirrors:
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-ystream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman
          


### PR DESCRIPTION
## Summary

- Updates the ImageDigestMirrorSet to include ystream component mirrors alongside existing ocp-bpfman components
- Enables Konflux nudging to work correctly when ystream components build
- Maintains backwards compatibility with existing release branches using legacy ocp-bpfman naming

## Details

The mirrors now map each registry.redhat.io source to both:
- New ystream components (e.g., `bpfman-daemon-ystream`)  
- Legacy ocp-bpfman components (e.g., `ocp-bpfman`)

This follows the pattern established by the NetObserv operator for managing multiple component streams.

## Why this change is needed

Currently, when the `bpfman-daemon-ystream` component builds in the bpfman repository, it doesn't trigger nudge PRs in bpfman-operator. This is because the operator's nudge files reference `registry.redhat.io/bpfman/bpfman`, which only maps to the old `ocp-bpfman` component in the ImageDigestMirrorSet. Adding the ystream mirrors allows the nudge system to recognise when ystream components are updated.