### PR TITLE
docs: add sync-version documentation to OpenShift tools

### DIFF
--- a/hack/openshift/Makefile
+++ b/hack/openshift/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "  transform-catalog            Update catalog index with Red Hat images"
 	@echo "  transform-catalog-container  Build catalog container with transformations"
 	@echo "  transform-all-container      Build all containers with transformations"
+	@echo "  set-version                  Copy VERSION value and replace in OpenShift Containerfiles"
 	@echo "  generate-rpm-lockfile        Generate rpms.lock.yaml for Konflux builds"
 	@echo "  format                       Format Python files with Black"
 	@echo "  format-check                 Check Python formatting"
@@ -57,4 +58,4 @@ format:
 format-check:
 	black --check *.py
 
-.PHONY: help transform-bundle transform-configmap transform-catalog transform-bundle-container transform-catalog-container transform-all-container generate-rpm-lockfile format format-check
+.PHONY: help transform-bundle transform-configmap transform-catalog transform-bundle-container transform-catalog-container transform-all-container set-version generate-rpm-lockfile format format-check

--- a/hack/openshift/README.md
+++ b/hack/openshift/README.md
@@ -46,6 +46,15 @@ Updates the catalog index to point to Red Hat images and sets timestamps.
   --operator-pullspec <operator-image>
 ```
 
+### `sync-version.sh`
+Synchronises the VERSION value from the repository root to all OpenShift-specific Containerfiles. The version information in OpenShift Containerfiles is stored as literal values in LABEL instructions (not dynamically read from the VERSION file), so this script updates those literal values to match the upstream VERSION.
+
+Run this after merging from upstream when the VERSION file changes:
+
+```bash
+make -C hack/openshift set-version
+```
+
 ### `Makefile`
 Test the transformations locally:
 - `transform-bundle` - Test bundle transformation
@@ -54,6 +63,7 @@ Test the transformations locally:
 - `transform-catalog` - Test catalog transformation
 - `transform-catalog-container` - Build catalog container with transformations
 - `transform-all-container` - Build all containers with transformations
+- `set-version` - Copy VERSION value and replace in OpenShift Containerfiles
 - `generate-rpm-lockfile` - Generate rpms.lock.yaml for Konflux builds
 - `format` - Format Python files with Black
 - `format-check` - Check Python formatting


### PR DESCRIPTION
## Summary

Add documentation for the `sync-version.sh` script and `set-version` Makefile target that were introduced in commit 132169a05ab21cdd7e5bd5af377d437b0ccff79b.

## Details

This PR documents the existing `sync-version.sh` script that copies the VERSION value from the repository root and replaces literal version values in OpenShift-specific Containerfiles. 

The script is necessary because Docker/Podman cannot dynamically read files for use in LABEL instructions, so the version information must be stored as literal values that need updating when the upstream VERSION file changes.

## Changes

- Added `sync-version.sh` documentation to hack/openshift/README.md
- Added `set-version` target to the Makefile help output
- Updated Makefile documentation section in README.md

## Related

References commit 132169a05ab21cdd7e5bd5af377d437b0ccff79b which introduced the sync-version.sh script.

## Usage

After merging from upstream when the VERSION file changes:
```bash
make -C hack/openshift set-version
```