### PR TITLE
tekton: temporarily build for x86_64 only to speed up pipelines

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -477,9 +477,6 @@ spec:
     type: string
   - default:
     - localhost
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array


### PR DESCRIPTION
## Summary

Temporarily reduce build platforms to x86_64 only to speed up pipeline execution during testing.

## Purpose

- Speed up pipeline builds from ~30+ minutes to ~5-10 minutes
- Allow faster iteration while testing nudge system and CEL expressions
- Make it practical to observe the full nudge cycle in reasonable time

## Changes

- Updated `.tekton/multi-arch-build-pipeline.yaml` to build only for `localhost` (x86_64)
- Removed `linux/arm64`, `linux/ppc64le`, `linux/s390x` from default platforms

## Note

This is a temporary change for testing purposes. Once we've verified the nudge system behaviour, we should revert this to restore multi-arch builds.

## Test Plan

1. Merge this PR
2. Subsequent pipeline runs will be significantly faster
3. Can observe complete nudge cycles more quickly
4. Revert once testing is complete