### PR TITLE
tekton: add hack/konflux path to push pipeline CEL expressions

### DIFF
--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -14,7 +14,8 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
+      || "hack/konflux/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -12,7 +12,7 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -14,7 +14,8 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
+      || "hack/konflux/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream


### PR DESCRIPTION
## Summary

Add `hack/konflux/***` to the CEL expressions in y-stream push pipelines to ensure nudge file updates trigger rebuilds.

## Problem

When Konflux updates image digest files in `hack/konflux/images/` (the nudge files), no pipelines were triggered because this path wasn't included in the CEL expression filters. This was demonstrated by PR #887 which updated `bpfman.txt` but triggered no builds upon merge.

## Solution  

Update the CEL expressions in the three y-stream push pipelines to include `"hack/konflux/***".pathChanged()`:
- `bpfman-agent-ystream-push.yaml`
- `bpfman-operator-ystream-push.yaml`
- `bpfman-operator-bundle-ystream-push.yaml`

## Why only push pipelines?

- Nudge file updates are automated by Konflux bots and merged directly
- They don't need PR validation builds
- Only post-merge (push) rebuilds are necessary

## Testing

PR #888 demonstrated that the CEL expressions work correctly for other paths (`cmd/***`). This change extends that same functionality to the nudge file path.

## Impact

After this merges, when external dependencies are updated (like the bpfman daemon from the bpfman repository), the resulting nudge file changes will correctly trigger component rebuilds, maintaining version synchronisation across the stack.