### PR TITLE
tekton: fix build-nudge-files to point to correct image files

### DIFF
--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman.txt
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-agent.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: ""
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
## Summary

Fix the `build-nudge-files` annotations in push pipelines to point to the correct image reference files, restoring the nudging system functionality.

## Problem

After refactoring image references from shell scripts to separate `.txt` files in `hack/konflux/images/`, the build-nudge-files annotations were not updated. This broke the nudging system:

- **bpfman-operator-ystream**: Had empty `build-nudge-files: ""`
- **bpfman-agent-ystream**: Pointed to wrong file (`hack/konflux/images/bpfman.txt` - the external daemon)

## Solution

Update the annotations to point to the correct files:
- **bpfman-operator-ystream**: `hack/konflux/images/bpfman-operator.txt`
- **bpfman-agent-ystream**: `hack/konflux/images/bpfman-agent.txt`

## Impact

Once merged, when operator or agent builds complete:
1. Konflux will create PRs updating the respective `.txt` files with new image SHAs
2. Those PRs will trigger rebuilds (thanks to PR #890's CEL expression fix)
3. The nudging cascade will work as it did on release-4.19

## Testing

After merge, any change that triggers operator/agent rebuilds should result in nudge PRs updating their image reference files.

## Related

- PR #890: Added `hack/konflux/***` to CEL expressions so nudge file changes trigger rebuilds
- This PR: Ensures the nudge files actually get updated when components build