### PR TITLE
Re-enable ocp-* pipeline nudging (Hail Mary attempt)

### DIFF
--- a/.tekton/ocp-bpfman-agent-push.yaml
+++ b/.tekton/ocp-bpfman-agent-push.yaml
@@ -7,7 +7,13 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: "false"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-agent-pull-request.yaml".pathChanged()
+      || ".tekton/ocp-bpfman-agent-push.yaml".pathChanged() || "apis/***".pathChanged()
+      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-bundle-push.yaml
+++ b/.tekton/ocp-bpfman-operator-bundle-push.yaml
@@ -7,7 +7,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: "false"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"  && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-bundle-pull-request.yaml".pathChanged()
+      || ".tekton/ocp-bpfman-operator-bundle-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
+      || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator

--- a/.tekton/ocp-bpfman-operator-push.yaml
+++ b/.tekton/ocp-bpfman-operator-push.yaml
@@ -7,7 +7,13 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: "false"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/ocp-bpfman-operator-pull-request.yaml".pathChanged()
+      || ".tekton/ocp-bpfman-operator-push.yaml".pathChanged() || "apis/***".pathChanged()
+      || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-operator


### PR DESCRIPTION
## Summary

**Hail Mary attempt** to restore nudging by re-enabling the ocp-* component pipelines. Based properly on downstream/main this time.

## Problem

After creating ystream components, nudging stopped working entirely:
- ystream push pipelines don't trigger because PipelinesAsCode can't match `ocp-bpfman-agent` Repository CR to `bpfman-agent-ystream-on-push` pipeline names
- ocp pipelines were disabled (CEL expressions set to "false") in PR #879
- No push builds = no nudge PRs = no way to verify anything works

## What This Does

Restores the ocp-* push pipeline CEL expressions from commit a2dbfae3 (before they were disabled). This should:
1. Trigger ocp-* component builds on push to main
2. Generate nudge PRs when builds complete
3. Prove the nudging mechanism still works

## Files Changed

- `.tekton/ocp-bpfman-agent-push.yaml` - CEL expression restored
- `.tekton/ocp-bpfman-operator-push.yaml` - CEL expression restored  
- `.tekton/ocp-bpfman-operator-bundle-push.yaml` - CEL expression restored

## Next Steps

If this works and we see nudge PRs:
- We know the infrastructure works
- We can fix ystream by creating proper Repository CRs or renaming pipelines

If this doesn't work:
- Something else is broken in the nudging chain
- Need to investigate Mintmaker, service accounts, or other infrastructure

This is temporary - just need to see SOMETHING nudge to know the system works.