### PR TITLE
Restore multi-arch builds

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -477,6 +477,9 @@ spec:
     type: string
   - default:
     - localhost
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array


### PR DESCRIPTION
## Summary

Restore multi-architecture builds that were temporarily disabled in PR #889.

## Context

PR #889 temporarily reduced build platforms to x86_64 only to speed up pipeline execution during testing of the nudge system. Now that testing is complete, this change restores the full set of build platforms.

## Changes

- Reverts commit ad430074 from PR #889
- Restores build platforms: `linux/arm64`, `linux/ppc64le`, `linux/s390x`

## Test Plan

- [ ] Pipeline builds successfully for all architectures
- [ ] Multi-arch container images are produced