### PR TITLE
tekton: fix CEL expressions to prevent circular build triggers

### DIFF
--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -14,8 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -12,7 +12,8 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/***".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "hack/konflux/images/bpfman.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -14,8 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream


### PR DESCRIPTION
Remove the `hack/konflux/***` wildcard from bpfman-operator-ystream and bpfman-agent-ystream push pipelines to prevent these components from rebuilding when their own image digest files are updated by Konflux nudging.

The wildcard pattern was added in commit 6850308 whilst debugging nudging issues, but the actual problem was fixed in PR #894. The broad pattern causes unnecessary rebuilds: when PR #912 updated `hack/konflux/images/bpfman.txt`, it triggered a rebuild of bpfman-operator-ystream even though no operator code changed.

Replace the wildcard in bpfman-operator-bundle-ystream with explicit paths to the three image files it packages: `hack/konflux/images/bpfman-operator.txt`, `hack/konflux/images/bpfman-agent.txt`, and `hack/konflux/images/bpfman.txt`. The bundle must rebuild when any component image changes.

This matches how NetObserv handles nudging: components don't trigger on their own nudge files, and the bundle explicitly lists its dependencies.

Related: PR #912 (revealed the issue), PR #894 (fixed the actual nudging problem), commit 6850308 (added the wildcards)