### PR TITLE
tekton: fix nudging configuration for proper component dependencies

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt, hack/konflux/images/bpfman-agent.txt, hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
@@ -12,8 +11,7 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "hack/konflux/images/bpfman.txt".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -14,7 +14,8 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream


### PR DESCRIPTION
## Fix nudging and rebuild triggers based on component relationships

This PR corrects the nudging configuration to properly reflect how our components depend on each other.

## The Problem

After analysing the nudging behaviour and comparing with working examples (NetObserv), we found:
- Bundle had incorrect `build-nudge-files` pointing to component image files it consumes rather than produces
- Operator wasn't rebuilding when agent/daemon images changed (but it needs these for its ConfigMap)
- Bundle was rebuilding for all image changes instead of just operator changes

## The Solution

### bpfman-operator-ystream changes:
- Add CEL triggers for `hack/konflux/images/bpfman.txt` and `bpfman-agent.txt`
- When daemon or agent updates, operator rebuilds to update ConfigMap with new image references
- Keeps its own `build-nudge-files: hack/konflux/images/bpfman-operator.txt`

### bpfman-operator-bundle-ystream changes:
- Remove incorrect `build-nudge-files` annotation (bundle doesn't produce image references for others)
- Only trigger on `hack/konflux/images/bpfman-operator.txt` changes
- Bundle rebuilds only when operator updates, not for every component change

## Expected Flow

1. bpfman-daemon builds → updates `bpfman.txt` → operator rebuilds → bundle rebuilds
2. bpfman-agent builds → updates `bpfman-agent.txt` → operator rebuilds → bundle rebuilds  
3. bpfman-operator changes → operator rebuilds → updates `bpfman-operator.txt` → bundle rebuilds

## Testing

After this merges, the next nudge from bpfman should trigger operator rebuild (due to daemon change) followed by bundle rebuild (due to operator change).

## Related

- #913 - Previous CEL expression fix that removed wildcards
- #916 - Nudge PR that revealed the configuration issues
- https://github.com/openshift/bpfman/pull/293 - Test PR to verify nudging