### PR TITLE
Test: Verify nudge cascade with corrected component dependencies

### DIFF
--- a/cmd/nudge-cascade-test.txt
+++ b/cmd/nudge-cascade-test.txt
@@ -1,0 +1,7 @@
+Test file to verify nudge cascade after component nudges-ref fixes.
+
+This file triggers operator and agent rebuilds when merged.
+Can be removed after testing is complete.
+
+Date: 2025-09-25
+Related: Component nudges-ref patched to fix build dependencies


### PR DESCRIPTION
## Test PR to verify nudge cascade after component fixes

This PR adds a dummy file to test that the corrected component nudges-ref configuration works properly.

## What was fixed

Component `build-nudges-ref` were patched:
- bpfman-daemon-ystream → nudges → bpfman-operator-ystream (was bundle)
- bpfman-agent-ystream → nudges → bpfman-operator-ystream (was bundle)  
- bpfman-operator-ystream → nudges → bpfman-operator-bundle-ystream (unchanged)

## Expected behaviour

When this merges, the `cmd/***` path change should trigger:
1. **bpfman-operator-ystream** rebuild (CEL matches `cmd/***`)
2. **bpfman-agent-ystream** rebuild (CEL matches `cmd/***`)
3. **bpfman-operator-bundle-ystream** rebuild via Component nudges-ref from operator

This tests that the component nudging cascade works correctly.

## Clean up

The dummy file can be removed after verifying the cascade works.

## Related

- PR #888 - Similar test approach
- PR #917 - Fixed CEL expressions for proper rebuild triggers