### PR TITLE
Add missing nudge file annotation for operator bundle

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator-bundle.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
## Summary
- Add missing `build.appstudio.openshift.io/build-nudge-files` annotation to the bpfman-operator-bundle-ystream push pipeline
- This ensures the bundle digest file (`hack/konflux/images/bpfman-operator-bundle.txt`) gets automatically updated when the bundle is rebuilt

## Problem
The bpfman-operator-bundle-ystream component builds new images when dependencies change but doesn't update its digest file. The other components (agent and operator) have nudge file annotations that automatically update their digest files, but the bundle was missing this configuration.

## Test plan
- [ ] Verify the annotation is correctly formatted
- [ ] Confirm the path matches the existing bundle digest file location
- [ ] After merge, verify that future bundle builds update the digest file