### PR TITLE
Trigger rebuild for catalog bundle updates

### DIFF
--- a/cmd/nudge-cascade-test.txt
+++ b/cmd/nudge-cascade-test.txt
@@ -5,3 +5,6 @@ Can be removed after testing is complete.
 
 Date: 2025-09-25
 Related: Component nudges-ref patched to fix build dependencies
+
+Update: 2025-09-30
+Testing catalog bundle reference updates to pick up latest builds


### PR DESCRIPTION
Dummy change to trigger operator/agent rebuilds which will cascade to bundle rebuilds via component nudges-ref.

This ensures the catalog picks up the latest bundle SHAs.