### PR TITLE
Configure bundle Tekton pipeline to use :latest tag

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
   - name: dockerfile
     value: Containerfile.bundle.openshift
   - name: prefetch-input


### PR DESCRIPTION
## Summary

Configure the bundle Tekton pipeline to use `:latest` tag following the Network Observability Operator's approach, providing stable bundle references for testing and CI workflows.

## Changes

- Update `bpfman-operator-bundle-ystream-push.yaml` to use `:latest` tag instead of `{{revision}}` 
- Bundle images will now be tagged as `bpfman-operator-bundle-ystream:latest`
- Operator and agent images continue using revision-based tags (unchanged)

## Rationale

The Network Observability Operator team uses `:latest` tags specifically for their bundle images, allowing them to reference `catalog-ystream:latest` in tests without constantly updating digest references. This provides:

- Stable bundle references for CI/testing
- Easier integration workflows
- Consistent approach across OpenShift operators

## Test Plan

- [x] Verify only bundle pipeline configuration is modified
- [ ] Confirm `:latest` tags are created after merge
- [ ] Test bundle references work with stable `:latest` tag

Following NOO's successful pattern for streamlined bundle management.