### PR TITLE
Test agent nudge to bundle flow after PR #969

### DIFF
--- a/cmd/nudge-test.txt
+++ b/cmd/nudge-test.txt
@@ -5,5 +5,5 @@ It will trigger builds for components that monitor cmd/*** paths.
 
 This file can be safely deleted after testing.
 
-Test timestamp: 2025-09-24
-Purpose: Verify pipeline triggers after merge
+Test timestamp: 2025-10-14
+Purpose: Verify agent nudges bundle directly after PR #969


### PR DESCRIPTION
Trigger an agent build to verify the optimisation from PR #969 is working.

**Expected behaviour:**
1. Agent build completes
2. Nudge PR created updating `hack/konflux/images/bpfman-agent.txt`
3. PR targets `bpfman-operator-bundle-ystream` (not `bpfman-operator-ystream`)
4. When PR merges, bundle rebuilds
5. Operator does NOT rebuild

This validates that agent updates no longer cause redundant operator rebuilds.