### PR TITLE
Remove nudge test files

### DIFF
--- a/cmd/nudge-cascade-test.txt
+++ b/cmd/nudge-cascade-test.txt
@@ -1,7 +1,0 @@
-Test file to verify nudge cascade after component nudges-ref fixes.
-
-This file triggers operator and agent rebuilds when merged.
-Can be removed after testing is complete.
-
-Date: 2025-09-25
-Related: Component nudges-ref patched to fix build dependencies

--- a/cmd/nudge-test.txt
+++ b/cmd/nudge-test.txt
@@ -1,9 +1,0 @@
-# Nudge Test File
-
-This is a temporary file to test CEL expression triggers.
-It will trigger builds for components that monitor cmd/*** paths.
-
-This file can be safely deleted after testing.
-
-Test timestamp: 2025-10-14 (second test)
-Purpose: Clean end-to-end test of agent→bundle nudge optimization


### PR DESCRIPTION
## Summary

Remove temporary test files that were used to validate the agent→bundle nudge optimisation (PR #969).

## Files Removed

- `cmd/nudge-cascade-test.txt`
- `cmd/nudge-test.txt`

These files were created to trigger component rebuilds via CEL expressions and verify that agent updates no longer cause unnecessary operator rebuilds. The optimisation has been validated and documented in [PR #969](https://github.com/openshift/bpfman-operator/pull/969#issuecomment-3401316613).

## Test Results

The end-to-end test (PR #973) successfully demonstrated:

- Agent builds now create PRs targeting the bundle directly (not operator)
- Operator does not rebuild when agent nudge PRs merge
- Bundle correctly rebuilds from both operator and agent nudges

The test files are no longer needed.