### PR TITLE
Complete agent→bundle nudge optimisation

### DIFF
--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged())
+      || "hack/konflux/images/bpfman.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream


### PR DESCRIPTION
## Summary

Complete the agent→bundle nudge optimisation by removing the bpfman-agent.txt file watch from the operator's CEL expression.

## Problem

The optimisation begun in PR #969 was incomplete. Whilst the agent's `build-nudges-ref` was redirected to target the bundle directly, the operator's CEL expression still watched `hack/konflux/images/bpfman-agent.txt`. This caused unnecessary operator rebuilds when agent image updates merged.

Evidence from PR #978: When the agent nudge PR merged, both the bundle AND operator rebuilt:
- `bpfman-operator-bundle-ystream-on-push-sd4nc` started at 11:48:13Z ✓ (expected)
- `bpfman-operator-ystream-on-push-ztwjb` started at 11:48:13Z ✗ (unnecessary)

## Root Cause

The operator does not use the agent image reference at build time—it reads it from the ConfigMap at runtime (see `controllers/bpfman-operator/configmap.go:368`). Therefore, operator rebuilds from agent image changes are redundant.

## Solution

Remove `hack/konflux/images/bpfman-agent.txt` from the operator's CEL expression. The bundle's CEL expression already watches this file (added in PR #969), so agent updates will still trigger bundle rebuilds to update the ConfigMap.

## Changes

- `.tekton/bpfman-operator-ystream-push.yaml`: Remove `bpfman-agent.txt` from CEL expression
- `hack/konflux/README.md`: Update documentation to reflect current configuration

## After This PR

Agent updates will follow this flow:
1. Agent builds → Creates nudge PR targeting bundle
2. Nudge PR merges → Only bundle rebuilds (operator does not rebuild)
3. Bundle embeds new agent image in ConfigMap
4. Operator reads agent image from ConfigMap at runtime

This eliminates redundant operator rebuilds whilst maintaining version coherence.