### PR TITLE
Add z-stream image mirrors to ImageDigestMirrorSet

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -7,17 +7,21 @@ spec:
     - source: registry.redhat.io/bpfman/bpfman-agent
       mirrors:
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-agent-ystream
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-agent-zstream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-agent
     - source: registry.redhat.io/bpfman/bpfman-operator-bundle
       mirrors:
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-zstream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator-bundle
     - source: registry.redhat.io/bpfman/bpfman-rhel9-operator
       mirrors:
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-ystream
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-zstream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman-operator
     - source: registry.redhat.io/bpfman/bpfman
       mirrors:
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-ystream
+         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-zstream
          - quay.io/redhat-user-workloads/ocp-bpfman-tenant/ocp-bpfman
          


### PR DESCRIPTION
## Summary

Add z-stream equivalents for all bpfman component mirrors to ensure proper image resolution for both y-stream and z-stream builds.

## Changes

- Added z-stream mirrors for `bpfman-agent`
- Added z-stream mirrors for `bpfman-operator-bundle`
- Added z-stream mirrors for `bpfman-operator`
- Added z-stream mirrors for `bpfman-daemon`

This ensures that both y-stream (main branch builds) and z-stream (release branch builds) images can be properly resolved through the ImageDigestMirrorSet configuration.

## Related

See also: https://github.com/openshift/bpfman-catalog/pull/26