### PR TITLE
Remove release label from bundle Containerfile

### DIFF
--- a/Containerfile.bundle.openshift
+++ b/Containerfile.bundle.openshift
@@ -75,7 +75,6 @@ LABEL name="bpfman-operator" \
       io.k8s.description="The bpfman-operator manage bpfman programs on every node. ." \
       io.openshift.tags="bpfman-operator" \
       version="0.5.7-dev" \
-      release="0.5.7-dev" \
       url="https://github.com/openshift/bpfman-operator" \
       vendor="Red Hat, Inc." \
       summary="Bpfman Operator"


### PR DESCRIPTION
## Summary

Remove the explicit `release` label from the bundle Containerfile to allow the build system to manage release versioning automatically.

## Details

The release label in `Containerfile.bundle.openshift` was set to a static value (`release="0.5.7-dev"`), but the build system automatically manages release tagging with timestamp-based values (as evidenced by tags like `0.5.6-1760606612` in the registry). This explicit label conflicts with the build pipeline's automated release tagging mechanism.

By removing this label, the build system can properly manage release versioning without conflicts.

## Changes

- Removed `release="0.5.7-dev"` from `Containerfile.bundle.openshift`