### PR TITLE
Use OPENSHIFT-VERSION to set CSV version in bundle transformations

### DIFF
--- a/Containerfile.bundle.openshift
+++ b/Containerfile.bundle.openshift
@@ -40,7 +40,8 @@ RUN cp /manifests/bpfman-config_v1_configmap.yaml /tmp/bpfman-config_v1_configma
 
 RUN hack/openshift/update-bundle.py \
     --csv-file /manifests/bpfman-operator.clusterserviceversion.yaml \
-    --image-pullspec "$(cat hack/konflux/images/bpfman-operator.txt)"
+    --image-pullspec "$(cat hack/konflux/images/bpfman-operator.txt)" \
+    --version "${BUILDVERSION}"
 
 RUN hack/openshift/update-configmap.py \
     --configmap-file /manifests/bpfman-config_v1_configmap.yaml \

--- a/hack/openshift/Makefile
+++ b/hack/openshift/Makefile
@@ -17,7 +17,8 @@ transform-bundle:
 	git checkout HEAD -- ../../bundle/manifests/bpfman-operator.clusterserviceversion.yaml
 	./update-bundle.py \
 		--csv-file ../../bundle/manifests/bpfman-operator.clusterserviceversion.yaml \
-		--image-pullspec "$$(cat ../konflux/images/bpfman-operator.txt)"
+		--image-pullspec "$$(cat ../konflux/images/bpfman-operator.txt)" \
+		--version "$$(grep BUILDVERSION ../../OPENSHIFT-VERSION | cut -d= -f2)"
 
 transform-configmap:
 	@echo "Restoring ConfigMap file from git to ensure clean baseline..."

--- a/hack/openshift/README.md
+++ b/hack/openshift/README.md
@@ -23,7 +23,8 @@ Changes the ClusterServiceVersion file to use Red Hat images and adds OpenShift 
 ```bash
 ./hack/openshift/update-bundle.py \
   --csv-file bundle/manifests/bpfman-operator.clusterserviceversion.yaml \
-  --image-pullspec <operator-image>
+  --image-pullspec <operator-image> \
+  --version <version>
 ```
 
 ### `update-configmap.py`
@@ -38,13 +39,13 @@ Replaces image references in the ConfigMap with Red Hat registry images.
 
 
 ### `OPENSHIFT-VERSION`
-Contains the version number used for OpenShift builds. All OpenShift-specific Containerfiles use this value via a build argument (`BUILDVERSION`). Update this file when preparing a new release:
+Contains the version number used for OpenShift builds. All OpenShift-specific Containerfiles use this value via a build argument (`BUILDVERSION`), and `update-bundle.py` uses it to set the CSV version field. Update this file when preparing a new release:
 
 ```bash
 echo "BUILDVERSION=0.5.7" > OPENSHIFT-VERSION
 ```
 
-The Containerfiles read this at build time using `--build-arg-file OPENSHIFT-VERSION`.
+The Containerfiles read this at build time using `--build-arg-file OPENSHIFT-VERSION`, and the transformation scripts extract the version to update bundle metadata.
 
 ### `Makefile`
 Test the transformations locally:
@@ -105,7 +106,8 @@ Or run the scripts directly:
 # Bundle transformation
 hack/openshift/update-bundle.py \
   --csv-file bundle/manifests/bpfman-operator.clusterserviceversion.yaml \
-  --image-pullspec "$(cat hack/openshift/konflux/images/bpfman-operator.txt)"
+  --image-pullspec "$(cat hack/openshift/konflux/images/bpfman-operator.txt)" \
+  --version "$(grep BUILDVERSION OPENSHIFT-VERSION | cut -d= -f2)"
 
 # ConfigMap transformation
 hack/openshift/update-configmap.py \

--- a/hack/openshift/update-bundle.py
+++ b/hack/openshift/update-bundle.py
@@ -22,6 +22,9 @@ def main():
     parser.add_argument(
         "--image-pullspec", required=True, help="Operator image pullspec"
     )
+    parser.add_argument(
+        "--version", help="Version to set in CSV spec.version field"
+    )
     parser.add_argument("--output", help="Output file (defaults to input file)")
     parser.add_argument(
         "files",
@@ -131,6 +134,12 @@ def main():
     bpfman_operator_csv["metadata"]["annotations"][
         "features.operators.openshift.io/token-auth-gcp"
     ] = "false"
+
+    # Update version if provided
+    if args.version:
+        if "spec" not in bpfman_operator_csv:
+            bpfman_operator_csv["spec"] = {}
+        bpfman_operator_csv["spec"]["version"] = args.version.strip()
 
     try:
         if args.output == "-":


### PR DESCRIPTION
## Summary

Extend the bundle transformation process to set the CSV spec.version field from the OPENSHIFT-VERSION file, ensuring consistency between the container image version labels and the bundle metadata version.

## Changes

Previously, the CSV version field retained the upstream development version (e.g., 0.5.7-dev), whilst the Containerfile labels used the downstream release version from OPENSHIFT-VERSION (e.g., 0.5.6). This change ensures both the CSV spec.version and container labels use the same downstream version from OPENSHIFT-VERSION.

- Add `--version` parameter to `update-bundle.py` script
- Update Makefile `transform-bundle` target to extract and pass version from OPENSHIFT-VERSION
- Update `Containerfile.bundle.openshift` to pass BUILDVERSION to update-bundle.py
- Update documentation to reflect the new version parameter usage

The version update is optional; when not specified, the script maintains its existing behaviour, leaving the CSV version unchanged.

## Testing

- Verified `make -C hack/openshift transform-bundle` correctly updates CSV version to 0.5.6 from OPENSHIFT-VERSION
- Verified `make -C hack/openshift transform-bundle-container` successfully builds with version correctly updated in containerised environment