### PR TITLE
Add OPENSHIFT-VERSION to Tekton pipeline trigger conditions

### DIFF
--- a/.tekton/bpfman-agent-zstream-pull-request.yaml
+++ b/.tekton/bpfman-agent-zstream-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-agent-zstream-push.yaml
+++ b/.tekton/bpfman-agent-zstream-push.yaml
@@ -14,7 +14,8 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -12,7 +12,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged())
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged())
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -12,7 +12,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged())
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-ystream-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged())
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-zstream-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged())
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged())
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Summary

Ensure bundle and operator builds are triggered when OPENSHIFT-VERSION changes. This guarantees that the CSV spec.version field is properly updated to match the container image version labels during bundle transformations.

## Changes

- Add `OPENSHIFT-VERSION` to CEL path changed triggers in all ystream and zstream pipeline files:
  - bpfman-operator-bundle-ystream-pull-request.yaml
  - bpfman-operator-bundle-ystream-push.yaml
  - bpfman-operator-ystream-pull-request.yaml
  - bpfman-operator-ystream-push.yaml
  - bpfman-operator-bundle-zstream-pull-request.yaml
  - bpfman-operator-bundle-zstream-push.yaml
  - bpfman-operator-zstream-pull-request.yaml
  - bpfman-operator-zstream-push.yaml
  - bpfman-agent-zstream-pull-request.yaml
  - bpfman-agent-zstream-push.yaml

## Problem Addressed

Previously, changes to OPENSHIFT-VERSION did not trigger pipeline rebuilds. The OPENSHIFT-VERSION file was introduced in PR #992 as the source of truth for downstream versioning. However, it was not included in the Tekton pipeline trigger conditions, which meant that when the version was updated (e.g., from 0.5.7 to 0.5.6), the bundles and operators would not be rebuilt.

This resulted in mismatched versions between:
- CSV spec.version (would remain at old value like 0.5.7-dev)
- Container image version labels (would be updated to new value like 0.5.6)

With these changes, the pipelines will automatically trigger when OPENSHIFT-VERSION is modified, ensuring the `--version` parameter is properly passed to `update-bundle.py` (as introduced in PR #1007), and consistency is maintained across all version metadata.