### PR TITLE
Add build-args-file support to single-arch-build-pipeline

### DIFF
--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -3,6 +3,65 @@ kind: Pipeline
 metadata:
   name: single-arch-build-pipeline
 spec:
+  params:
+  - name: git-url
+    description: Source Repository URL
+    type: string
+  - name: revision
+    description: Revision of the Source Repository
+    type: string
+    default: ""
+  - name: output-image
+    description: Fully Qualified Output Image
+    type: string
+  - name: path-context
+    description: Path to the source code of an application's component from where to build image
+    type: string
+    default: .
+  - name: dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter path-context
+    type: string
+    default: Dockerfile
+  - name: rebuild
+    description: Force rebuild image
+    type: string
+    default: "false"
+  - name: skip-checks
+    description: Skip checks against built image
+    type: string
+    default: "false"
+  - name: hermetic
+    description: Execute the build with network isolation
+    type: string
+    default: "false"
+  - name: prefetch-input
+    description: Build dependencies to be prefetched by Cachi2
+    type: string
+    default: ""
+  - name: image-expires-after
+    description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively
+    type: string
+    default: ""
+  - name: build-source-image
+    description: Build a source image
+    type: string
+    default: "false"
+  - name: prefetch-dev-package-managers-enabled
+    description: Enable development package managers for prefetch
+    type: string
+    default: "false"
+  - name: buildah-format
+    description: The format of the built container, oci or docker
+    type: string
+    default: "oci"
+  - name: build-args
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    type: array
+    default: []
+  - name: build-args-file
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    type: string
+    default: ""
   tasks:
   - name: init
     taskRef:
@@ -119,6 +178,11 @@ spec:
       - vcs-url=$(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
   - name: build-source-image
     taskRef:
       resolver: bundles


### PR DESCRIPTION
## Summary

Add support for the build-args-file parameter to the Tekton pipeline, enabling build arguments to be passed from a file to buildah during container builds. This parameter is already specified in the pipeline run configurations but was missing from the pipeline definition itself.

## Changes

- Add spec.params section with build-args and build-args-file parameters
- Pass BUILD_ARGS and BUILD_ARGS_FILE to the buildah-oci-ta task

## Problem Addressed

Currently, the bundle pipeline run YAML files pass a `build-args-file: OPENSHIFT-VERSION` parameter, but the pipeline definition doesn't declare this parameter or pass it to the buildah task. As a result, the OPENSHIFT-VERSION file is ignored during builds, and the CSV spec.version field cannot be updated from the BUILDVERSION value.

This causes a mismatch between:
- CSV spec.version (remains at upstream dev version like 0.5.7-dev)
- Container image version labels (set to downstream version like 0.5.6)

## Verification

Verified locally that `podman build --build-arg-file OPENSHIFT-VERSION` correctly:
1. Reads BUILDVERSION=0.5.6 from the file
2. Passes it to update-bundle.py via --version parameter
3. Updates CSV spec.version from 0.5.7-dev to 0.5.6

Confirmed that buildah-oci-ta:0.6 task accepts and processes BUILD_ARGS_FILE parameter.

## Related PRs

- #992 - Introduced OPENSHIFT-VERSION file
- #1007 - Added --version parameter to update-bundle.py
- #1016 - Added OPENSHIFT-VERSION to Tekton trigger conditions

This PR completes the chain by ensuring the pipeline actually uses the build-args-file parameter that was already configured in the pipeline runs.