### PR TITLE
Restore release label to bundle Containerfile for Konflux validation

### DIFF
--- a/Containerfile.bundle.openshift
+++ b/Containerfile.bundle.openshift
@@ -100,6 +100,7 @@ LABEL name="bpfman-operator" \
       io.k8s.description="The bpfman-operator manage bpfman programs on every node. ." \
       io.openshift.tags="bpfman-operator" \
       version=$BUILDVERSION \
+      release=$BUILDVERSION \
       url="https://github.com/openshift/bpfman-operator" \
       vendor="Red Hat, Inc." \
       summary="Bpfman Operator"


### PR DESCRIPTION
## Summary

Restore the `release` label that was removed in PR #991, as it is required by the Konflux release pipeline's `verify-conforma` task.

## Problem Analysis

All bundle releases to production have been failing since PR #991 was merged on **17 October 2025 at 11:04 UTC**. Investigation revealed that the `verify-conforma` task in the Konflux managed release pipeline explicitly requires the `release` label.

### Timeline of Failures

- **Last successful bundle release**: 16 October 2025 09:54 UTC
  - Bundle: `0.5.7-dev` 
  - Status: ✅ Succeeded (had `release` label)
  
- **PR #991 merged**: 17 October 2025 11:04 UTC
  - Change: Removed `release="0.5.7-dev"` label
  - Rationale: Assumed build system would manage it automatically
  
- **First failed bundle release**: 17 October 2025 07:22 UTC
  - Error: `The required "release" label is missing`
  - Task: `verify-conforma` (step-assert)
  
- **Subsequent releases**: 20+ consecutive bundle release failures
  - Same error in all cases
  - Operator releases (non-bundle) continued to succeed

### Validation Error

The `verify-conforma` task failure message:
```
"violations": [{
  "msg": "The required \"release\" label is missing. Label description: Release Number for this version.",
  "metadata": {
    "code": "labels.required_labels",
    "collections": ["redhat"],
    "term": "release",
    "title": "Required labels"
  }
}]
```

### Manual Test Confirmation

A manual release was triggered (23 October 2025) using snapshot `bpfman-ystream-2gdg4` to confirm the issue:
- Release: `bpfman-ystream-2gdg4-manual-test-79hfs`
- Managed pipeline: `rhtap-releng-tenant/managed-8fsf8`
- Result: ❌ Failed at `verify-conforma` task
- Error: Same missing `release` label violation

## Solution

Add back the `release` label using `$BUILDVERSION` to ensure it matches the version being built:

```dockerfile
release=$BUILDVERSION \
```

This approach:
- Satisfies the Konflux validation requirement
- Automatically tracks the version from `OPENSHIFT-VERSION`
- Works for all version formats (e.g., `0.5.7-dev-1`)

## Related PRs

- PR #991: Removed release label (merged 17 October 2025) - **caused the failures**
- PR #1027: Bump OPENSHIFT-VERSION to 0.5.7-dev-1 for OCP 4.20
- PR #1028: Automated component updates

## Testing

After this PR merges and a new bundle build completes, the `verify-conforma` task should pass and bundle releases should succeed.