### PR TITLE
Align bundle Containerfile labels with Red Hat OLM conventions

### DIFF
--- a/Containerfile.bpfman-agent.openshift
+++ b/Containerfile.bpfman-agent.openshift
@@ -49,8 +49,9 @@ LABEL name="bpfman/bpfman-agent" \
       io.k8s.display-name="Bpfman Agent" \
       summary="Bpfman agent manages the eBPF programs lifecycle." \
       description="The bpfman-agent manage bpfman ebpf programs on every node." \
-      io.k8s.description="The bpfman-agent manage bpfman programs on every node. ." \
+      io.k8s.description="The bpfman-agent manage bpfman programs on every node." \
       io.openshift.tags="bpfman-agent" \
+      maintainer="support@redhat.com" \
       version=$BUILDVERSION \
       vendor="Red Hat, Inc."
 

--- a/Containerfile.bpfman-operator.openshift
+++ b/Containerfile.bpfman-operator.openshift
@@ -47,8 +47,9 @@ LABEL name="bpfman/bpfman-operator" \
       io.k8s.display-name="eBPF Manager Operator" \
       summary="eBPF manager operator manages the eBPF programs lifecycle." \
       description="The bpfman-operator repository exists to deploy and manage bpfman within a Kubernetes cluster." \
-      io.k8s.description="The bpfman-operator repository exists to deploy and manage bpfman within a Kubernetes cluster. ." \
+      io.k8s.description="The bpfman-operator repository exists to deploy and manage bpfman within a Kubernetes cluster." \
       io.openshift.tags="bpfman-operator" \
+      maintainer="support@redhat.com" \
       version=$BUILDVERSION \
       vendor="Red Hat, Inc."
 

--- a/Containerfile.bundle.openshift
+++ b/Containerfile.bundle.openshift
@@ -99,6 +99,7 @@ LABEL name="bpfman-operator-bundle" \
       distribution-scope=public \
       io.k8s.description="Bpfman Operator bundle for OpenShift." \
       io.openshift.tags="bpfman-operator-bundle" \
+      maintainer="support@redhat.com" \
       version=$BUILDVERSION \
       release=$BUILDVERSION \
       url="https://github.com/openshift/bpfman-operator" \


### PR DESCRIPTION
## Summary

This PR updates container image labels across all three downstream Containerfiles (bundle, operator, and agent) to follow Red Hat OLM bundle naming conventions and container metadata standards as established by the Network Observability operator.

This PR builds on #1029 which restored the `release=$BUILDVERSION` label.

## Changes

### Critical: Bundle Label Conventions (Commit 1)

All changes in `Containerfile.bundle.openshift`:

| Label | Before | After |
|-------|--------|-------|
| `name` | `bpfman-operator` | `bpfman-operator-bundle` |
| `com.redhat.component` | `bpfman-operator` | `bpfman-operator-bundle-container` |
| `io.k8s.display-name` | `Bpfman Operator` | `Bpfman Operator Bundle` |
| `io.openshift.tags` | `bpfman-operator` | `bpfman-operator-bundle` |
| `description` | Describes operator | Describes bundle artifact |
| `io.k8s.description` | Describes operator | Describes bundle artifact |
| `summary` | `Bpfman Operator` | `Bpfman Operator Bundle` |

### Medium: Label Quality Improvements (Commit 2)

Changes across all three Containerfiles (bundle, operator, agent):

1. **Fixed double period typo** in `io.k8s.description`:
   - Before: `"... Kubernetes cluster. ."` and `"... every node. ."`
   - After: `"... Kubernetes cluster."` and `"... every node."`

2. **Added missing maintainer label** to all three images:
   - Added: `maintainer="support@redhat.com"`
   - Provides a support contact point following Red Hat standards

## Rationale

### Bundle vs Operator Naming

Bundle images are distinct artifacts from operator images and should be labelled accordingly to avoid confusion in registries and catalogs. This follows the established pattern used by the Network Observability operator:

**Network Observability Bundle Labels:**
```dockerfile
LABEL com.redhat.component="network-observability-operator-bundle-container"
LABEL name="network-observability-operator-bundle"
LABEL io.k8s.display-name="Network Observability Operator Bundle"
LABEL io.openshift.tags="network-observability-operator-bundle"
LABEL maintainer="support@redhat.com"
```

Reference: [netobserv bundle.Dockerfile.downstream](https://github.com/netobserv/network-observability-operator/blob/main/bundle.Dockerfile.downstream)

### Label Quality

The typo fixes and maintainer label addition bring all three Containerfiles into alignment with Red Hat's standard downstream container metadata practices as exemplified by the Network Observability operator.

## Testing

This change aligns our bundle metadata with the successfully releasing Network Observability operator bundles, which use identical label conventions and pass the same Konflux validation pipeline.

## Related Issues

- Builds on #1029 (which restored the `release` label)
- Fixes bundle naming conventions identified when comparing to netobserv
- Brings bpfman bundle labelling in line with Red Hat OLM standards