### PR TITLE
Align z-stream agent Tekton pipelines with y-stream configuration

### DIFF
--- a/.tekton/bpfman-agent-zstream-pull-request.yaml
+++ b/.tekton/bpfman-agent-zstream-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-agent-zstream-push.yaml
+++ b/.tekton/bpfman-agent-zstream-push.yaml
@@ -14,8 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "OPENSHIFT-VERSION".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
Remove OPENSHIFT-VERSION from z-stream agent pipeline trigger conditions to match the y-stream agent configuration. The OPENSHIFT-VERSION file only affects bundle CSV transformations and does not require agent image rebuilds.

## Background

PR #1016 (commit 2f5ade1d) added OPENSHIFT-VERSION watches to ensure bundle and operator builds trigger when version metadata changes. Whilst the commit message stated it updated "All ystream pipelines (bundle, operator)" and "All zstream pipelines (bundle, operator, agent)", the y-stream agent files were correctly left unchanged, but the z-stream agent files were updated to watch OPENSHIFT-VERSION.

This created an inconsistency: z-stream agent pipelines trigger on OPENSHIFT-VERSION changes whilst y-stream agent pipelines do not.

## Analysis

The bundle transformation process (see `hack/openshift/Makefile`) reads OPENSHIFT-VERSION directly to update the CSV `spec.version` field. It does not depend on the agent images being rebuilt. Therefore, changes to OPENSHIFT-VERSION should only trigger:
- Bundle builds (which perform CSV transformations)
- Operator builds (referenced by the bundle)

But not:
- Agent builds (not involved in CSV metadata)

## Changes

This PR removes `|| "OPENSHIFT-VERSION".pathChanged()` from:
- `.tekton/bpfman-agent-zstream-pull-request.yaml`
- `.tekton/bpfman-agent-zstream-push.yaml`

This prevents unnecessary agent rebuilds when OPENSHIFT-VERSION changes, whilst still ensuring the bundle pipeline correctly triggers to update CSV metadata.