### PR TITLE
Fix bundle build timing to prevent premature dependency references

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt,hack/konflux/images/bpfman-agent.txt,hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
@@ -11,8 +12,7 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt,hack/konflux/images/bpfman-agent.txt,hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
@@ -11,8 +12,7 @@ metadata:
       == "release-4.20" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Problem

Bundle builds were failing release validation with `olm.unmapped_references` violations because the bundle CSV/ConfigMap referenced operator/agent/daemon images at `registry.redhat.io` that had not been released yet:

```
✕ [Violation] olm.unmapped_references
  The "registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:7acfa64d..."
  CSV image reference is not in the snapshot or accessible.
```

## Root Cause

When commit ec021864 (September 2025) moved nudge files from `hack/openshift/konflux/` to `hack/konflux/`, the bundle CEL expressions were updated to explicitly monitor these nudge files using `pathChanged()`:

```yaml
|| "hack/konflux/images/bpfman-operator.txt".pathChanged()
|| "hack/konflux/images/bpfman-agent.txt".pathChanged()
```

This created a critical timing issue:

1. **pathChanged() triggers on git commits** - Bundle rebuilds immediately when PR merges
2. **Images aren't released yet** - The new operator/agent/daemon images exist only in `quay.io/redhat-user-workloads`
3. **Bundle embeds unreleased references** - CSV/ConfigMap reference `registry.redhat.io/...@sha256:NEW_SHA`
4. **Release validation fails** - Conforma checker cannot access unreleased images

## Why This Went Undetected

The issue only manifested when all these conditions occurred in sequence:

1. Operator/agent/daemon images were rebuilt (generating new SHAs)
2. Konflux created automated PRs to update nudge files with new SHAs
3. Bundle rebuild was triggered by nudge file `pathChanged()` events
4. Bundle was included in the same snapshot as unreleased images

This specific sequence didn't occur until:
- **PR #1033**: Bumped `OPENSHIFT-VERSION` to 0.5.8, triggering new operator/agent builds (SHA `7acfa64d`)
- **PR #1035**: Konflux automatically updated `hack/konflux/images/bpfman-operator.txt` with the new SHA
- **Bundle rebuild**: Triggered immediately by `pathChanged()`, embedding unreleased image references
- **Release failure**: Validation detected inaccessible images

Previous releases succeeded because the bundle wasn't included in snapshots (no bundle content had changed), so the validation never ran.

## The Fundamental Mistake

Using **`pathChanged()` CEL expressions** instead of **`build-nudge-files` annotations**:

| Approach | Trigger Point | Image Status | Result |
|----------|--------------|--------------|---------|
| `pathChanged()` | When PR merges (file modified) | Not released yet | ❌ Too early |
| `build-nudge-files` | After successful release | Released and accessible | ✅ Correct |

The nudge system is specifically designed to handle release ordering, but by using `pathChanged()`, the timing control was bypassed. The nudge system waits for releases to complete, then updates nudge files, then triggers dependent builds. But `pathChanged()` fires as soon as the PR merges, which is before the release completes.

## Solution

Remove nudge file path monitoring from bundle CEL expressions and use `build-nudge-files` annotations instead:

```yaml
annotations:
  build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt,hack/konflux/images/bpfman-agent.txt,hack/konflux/images/bpfman.txt
```

This ensures the correct cascade:

1. Operator/agent/daemon images build and release successfully
2. Post-release, Konflux updates their nudge files
3. `build-nudge-files` annotation triggers bundle rebuild
4. Bundle references only released, accessible images
5. Release validation succeeds

## Changes

- Add `build-nudge-files` annotations to bundle y-stream and z-stream push configurations, monitoring operator, agent, and daemon image nudge files
- Remove `hack/konflux/images/*.txt` path monitoring from bundle CEL expressions
- Bundle still rebuilds immediately for actual content changes (CSV, manifests, configuration, `OPENSHIFT-VERSION`)

## Testing

After this change, the workflow will be:
1. Merge this PR
2. Next operator/agent/daemon image release will succeed (no bundle in snapshot yet)
3. Konflux nudge system will update nudge files post-release
4. Bundle will rebuild with released image references
5. Bundle release will succeed with accessible images