### PR TITLE
Test bundle nudging mechanism with dummy file

### DIFF
--- a/hack/openshift/test-nudging.txt
+++ b/hack/openshift/test-nudging.txt
@@ -1,0 +1,9 @@
+This is a test file to verify that the bundle nudging mechanism works correctly.
+
+When this file is modified and merged to main, it should trigger the bundle build
+pipeline due to the CEL expression path condition: "hack/openshift/***".pathChanged()
+
+This ensures that PR #1036's changes to the Tekton pipeline CEL expressions didn't
+break the nudging mechanism for bundle builds.
+
+Test timestamp: 2025-10-23T20:05:00Z


### PR DESCRIPTION
## Summary

Add a test file in `hack/openshift/` to verify that changes in this directory correctly trigger bundle builds via the CEL expression path condition: `"hack/openshift/***".pathChanged()`.

## Purpose

This test ensures that PR #1036's changes to the Tekton pipeline CEL expressions didn't inadvertently break the nudging mechanism for bundle builds. When this PR is merged, the bundle build pipeline should be triggered automatically.

## Test Plan

- [ ] Verify that merging this PR triggers the bundle build pipeline
- [ ] Confirm that the bundle is built successfully
- [ ] Check that the nudging mechanism works as expected

## Follow-up

This is a follow-up to PR #1036 to validate the bundle nudging functionality.