### PR TITLE
Restore CEL path triggers for bundle nudge files

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -12,7 +12,8 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -12,7 +12,8 @@ metadata:
       == "release-4.20" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Summary

Restore the CEL expression path triggers for `hack/konflux/images/*.txt` files that were removed in PR #1036.

## Problem

Evidence shows that the `build-nudge-files` annotation alone does not trigger bundle rebuilds when the `.txt` files are updated:

- PR #1039 merged at 20:33:26Z (updated `bpfman-agent.txt`)
- PR #1040 merged at 20:36:07Z (updated `bpfman-operator.txt`)
- No bundle pipeline runs were triggered after either merge
- This indicates the `build-nudge-files` mechanism does not function as I expected

## Solution

Restore the working CEL path triggers whilst keeping the `build-nudge-files` annotation, providing redundancy until the annotation mechanism is confirmed to work.

## Changes

- Restore `hack/konflux/images/bpfman-operator.txt` path trigger
- Restore `hack/konflux/images/bpfman-agent.txt` path trigger  
- Keep `build-nudge-files` annotation for potential future use
- Apply to both y-stream and z-stream bundle push pipelines

## Test Plan

- [ ] Verify that merging this PR triggers bundle builds
- [ ] Confirm bundle rebuilds occur when `.txt` files are updated

## Related

- Partially reverts PR #1036
- Related to PRs #1039, #1040 (nudge PRs that did not trigger builds)