### PR TITLE
Revert "Fix bundle build timing to prevent premature dependency references"

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt,hack/konflux/images/bpfman-agent.txt,hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman-operator.txt,hack/konflux/images/bpfman-agent.txt,hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
Reverts openshift/bpfman-operator#1036

I'm now convinced the issues I discovered were transient infrastructure issues:

```
% tkn pr describe managed-9fq5h -n rhtap-releng-tenant | grep -A 5 -B 5 etcd
STARTED       DURATION   STATUS
4 hours ago   38s        Failed(CouldntGetTask)

Message

Pipeline rhtap-releng-tenant/ can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type git\nurl = https://github.com/konflux-ci/release-service-catalog.git\n": error requesting remote resource: error updating resource request "rhtap-releng-tenant/git-b12af515e8fd520298c5e91d9bfc3d44" with data: etcdserver: request timed out

Timeouts
 Pipeline:   1h15m0s
 Tasks:      1h15m0s
```