### PR TITLE
Test bundle nudging mechanism with updated timestamp

### DIFF
--- a/hack/openshift/test-nudging.txt
+++ b/hack/openshift/test-nudging.txt
@@ -6,4 +6,4 @@ pipeline due to the CEL expression path condition: "hack/openshift/***".pathChan
 This ensures that PR #1036's changes to the Tekton pipeline CEL expressions didn't
 break the nudging mechanism for bundle builds.
 
-Test timestamp: 2025-10-23T20:05:00Z
+Test timestamp: 2025-10-23T22:55:00Z


### PR DESCRIPTION
## Summary

Update the test timestamp in `hack/openshift/test-nudging.txt` to verify that the bundle nudging mechanism continues to work correctly.

## Purpose

This PR tests that changes in the `hack/openshift/` directory correctly trigger bundle builds via the CEL expression path condition: `"hack/openshift/***".pathChanged()`.

This is a follow-up test to PR #1038 to ensure the bundle build automation remains functional after the changes from PR #1036.

## Test Plan

- [ ] Verify that merging this PR triggers the bundle build pipeline
- [ ] Confirm that the bundle is built successfully
- [ ] Check that the nudging mechanism works as expected

## Follow-up

This is a second test of the bundle nudging functionality to validate the mechanism is working consistently.