### PR TITLE
Test bundle nudging with all 4 components having revision:main

### DIFF
--- a/hack/openshift/test-nudging.txt
+++ b/hack/openshift/test-nudging.txt
@@ -6,4 +6,4 @@ pipeline due to the CEL expression path condition: "hack/openshift/***".pathChan
 This ensures that PR #1036's changes to the Tekton pipeline CEL expressions didn't
 break the nudging mechanism for bundle builds.
 
-Test timestamp: 2025-10-23T22:55:00Z
+Test timestamp: 2025-10-24T00:15:00Z - Testing with all 4 components having revision:main


### PR DESCRIPTION
## Summary

Test that snapshots now include all 4 components after adding `revision: "main"` to the daemon and bundle components.

## Context

After comparing with netobserv-ystream (which consistently includes all 7 components in snapshots), we discovered that:
- **netobserv**: All 7 components have `spec.source.git.revision` specified  
- **bpfman** (before fix): Only agent and operator had `revision: "main"`, daemon and bundle had `revision: null`

## Fixes Applied

1. Patched `bpfman-daemon-ystream` component to add `revision: "main"` - [see comment](https://github.com/openshift/bpfman-operator/pull/1036#issuecomment-3439650277)
2. Patched `bpfman-operator-bundle-ystream` component to add `revision: "main"` - [see comment](https://github.com/openshift/bpfman-operator/pull/1036#issuecomment-3439655870)
3. Updated `IntegrationTestScenario` to add `contexts: [{"name": "application"}]` for application-level snapshots - [see comment](https://github.com/openshift/bpfman-operator/pull/1036#issuecomment-3439543994)

## Test Goal

Verify that when this PR is merged, the resulting snapshot includes **all 4 components**:
- ✅ bpfman-daemon-ystream
- ✅ bpfman-agent-ystream  
- ✅ bpfman-operator-ystream
- ✅ bpfman-operator-bundle-ystream

Previously, snapshots only included 2-3 components and excluded the daemon.

## Related

All investigation and fixes documented in PR #1036.