### PR TITLE
Fix bundle pipeline to trigger on daemon image updates

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -12,7 +12,9 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "hack/konflux/images/bpfman.txt".pathChanged()
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -13,7 +13,8 @@ metadata:
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "hack/konflux/images/bpfman.txt".pathChanged()
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream


### PR DESCRIPTION
## Summary

- Update bundle pipeline CEL expressions to watch `hack/konflux/images/bpfman.txt`
- Ensures bundle rebuilds when daemon component nudges it
- Fixes incoherent snapshots that contain new daemon images but stale ConfigMap references

## Problem

Currently, `bpfman-daemon-ystream` is configured to nudge `bpfman-operator-ystream`, which is incorrect because:

1. The operator binary does not embed daemon/agent image references at build time
2. The operator reads these references from the ConfigMap at runtime
3. When the daemon changes, only the bundle needs rebuilding (to update the ConfigMap)
4. Even if daemon nudged the bundle, the pipeline wouldn't trigger because `bpfman.txt` wasn't in the CEL expression

This results in snapshots containing new daemon images whilst the bundle's ConfigMap still references stale daemon digests, causing release failures.

## Changes

- Add `hack/konflux/images/bpfman.txt` to push pipeline CEL expression
- Add all three image reference files to pull-request pipeline CEL expression for consistency

## Required Cluster Change

The Konflux component configuration must also be updated. Apply this patch:

```bash
oc patch component bpfman-daemon-ystream -n ocp-bpfman-tenant \
  --type=json \
  -p='[{"op": "replace", "path": "/spec/build-nudges-ref/0", "value": "bpfman-operator-bundle-ystream"}]'
```

This changes the daemon's nudge target from `bpfman-operator-ystream` to `bpfman-operator-bundle-ystream`.

## Test Plan

After merging and applying the component patch:

1. Trigger a daemon build or wait for an automated build
2. Verify nudge PR created updating `hack/konflux/images/bpfman.txt`
3. Verify bundle pipeline triggers after nudge PR merges
4. Verify snapshot contains coherent references (bundle ConfigMap matches daemon digest in snapshot)