### PR TITLE
Add hermetic parameter to pipeline configurations

### DIFF
--- a/.tekton/bpfman-agent-ystream-pull-request.yaml
+++ b/.tekton/bpfman-agent-ystream-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: Containerfile.bpfman-agent.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -34,6 +34,8 @@ spec:
     value: Containerfile.bpfman-agent.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-agent-zstream-pull-request.yaml
+++ b/.tekton/bpfman-agent-zstream-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: Containerfile.bpfman-agent.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-agent-zstream-push.yaml
+++ b/.tekton/bpfman-agent-zstream-push.yaml
@@ -34,6 +34,8 @@ spec:
     value: Containerfile.bpfman-agent.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value: OPENSHIFT-VERSION
   - name: prefetch-input
     value: '{"packages": [{"type": "rpm", "path": "."}, {"type": "pip", "path": "."}]}'
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -36,6 +36,8 @@ spec:
     value: OPENSHIFT-VERSION
   - name: prefetch-input
     value: '{"packages": [{"type": "rpm", "path": "."}, {"type": "pip", "path": "."}]}'
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
@@ -37,6 +37,8 @@ spec:
     value: OPENSHIFT-VERSION
   - name: prefetch-input
     value: '{"packages": [{"type": "rpm", "path": "."}, {"type": "pip", "path": "."}]}'
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: OPENSHIFT-VERSION
   - name: prefetch-input
     value: '{"packages": [{"type": "rpm", "path": "."}, {"type": "pip", "path": "."}]}'
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-ystream-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: Containerfile.bpfman-operator.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: Containerfile.bpfman-operator.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-zstream-pull-request.yaml
@@ -37,6 +37,8 @@ spec:
     value: Containerfile.bpfman-operator.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: Containerfile.bpfman-operator.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'true'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Summary

Explicitly set the hermetic parameter to 'true' in all agent, operator, and bundle pipeline configurations (both ystream and zstream, push and pull-request) to restore the configuration present in the old ocp-bpfman-* components before they were purged.

## Problem

The old ocp-bpfman-* components (removed in commits 1ee631cd, 3042afb9, 4d90ec1b) all had `hermetic: "true"` explicitly set. The current bpfman-operator components do not have this parameter explicitly set, relying instead on the pipeline default of 'true'.

The Enterprise Contract policy requires explicit acknowledgement of the hermetic parameter at the PipelineRun level. Whilst the pipeline default is 'true', making this explicit ensures:
1. Clarity and consistency with the previous configuration
2. Satisfaction of EC policy requirements for explicit parameter acknowledgement  
3. Clear distinction from the bpfman daemon components which require `hermetic: 'false'` due to Rust/FIPS constraints

## Changes

Add `hermetic: 'true'` parameter to:
- `.tekton/bpfman-agent-ystream-{push,pull-request}.yaml`
- `.tekton/bpfman-agent-zstream-{push,pull-request}.yaml`
- `.tekton/bpfman-operator-ystream-{push,pull-request}.yaml`
- `.tekton/bpfman-operator-zstream-{push,pull-request}.yaml`
- `.tekton/bpfman-operator-bundle-ystream-{push,pull-request}.yaml`
- `.tekton/bpfman-operator-bundle-zstream-{push,pull-request}.yaml`

## Context

This mirrors the approach taken in openshift/bpfman PR #326 for daemon components, where hermetic was explicitly set (though to 'false' in that case due to the volatileConfig exception for non-hermetic builds).

The operator, agent, and bundle components build hermetically and do not require the volatileConfig exception that applies to the daemon components.