### PR TITLE
Remove nudge file path triggers from bundle CEL expressions

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -12,9 +12,7 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "hack/konflux/images/bpfman.txt".pathChanged()
-      || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -12,8 +12,7 @@ metadata:
       == "release-4.20" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Problem

Bundle builds fail release validation with `olm.unmapped_references` violations because bundle CSVs/ConfigMaps reference operator/agent/daemon images at `registry.redhat.io` that haven't been released yet.

## Root Cause

The bundle pipeline has **both** triggering mechanisms:
1. `pathChanged()` for `hack/konflux/images/*.txt` files (triggers immediately when nudge PR merges)
2. `build-nudge-files` annotation (triggers after images are released)

The `pathChanged()` fires **first**, before images are pushed to `registry.redhat.io`, causing bundles to embed unreleased image references.

## History

- **PR #1036** (Oct 23): Removed `pathChanged()`, added `build-nudge-files`
- **PR #1041** (Oct 23): Restored `pathChanged()` because `build-nudge-files` "didn't work"
- **PR #1042** (Oct 23): Removed `build-nudge-files`
- **PR #1043** (Oct 23): Restored `build-nudge-files`

Result: Both mechanisms exist, creating a race condition where `pathChanged()` triggers too early.

## Solution

Remove `pathChanged()` monitoring for:
- `hack/konflux/images/bpfman-operator.txt`
- `hack/konflux/images/bpfman-agent.txt`
- `hack/konflux/images/bpfman.txt`

Keep only `build-nudge-files` annotation, which triggers **after** images are released.

Bundle still rebuilds immediately for actual content changes (CSV, manifests, OPENSHIFT-VERSION).

## Verification

After this change:
1. Operator/agent/daemon images build and release successfully
2. Nudge system updates .txt files post-release
3. `build-nudge-files` triggers bundle rebuild
4. Bundle references only released, accessible images
5. Release EC validation succeeds

Fixes the "olm.unmapped_references" failures blocking all releases.