### PR TITLE
Restore hack/konflux/images path triggers in bundle CEL expressions

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -12,7 +12,8 @@ metadata:
       == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-ystream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged()
+      || "hack/konflux/images/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -12,7 +12,8 @@ metadata:
       == "release-4.20" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
-      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged()
+      || "hack/konflux/images/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Summary

Add `pathChanged()` monitoring for `hack/konflux/images/***` back to bundle pipeline CEL expressions for both ystream and zstream. This ensures bundle rebuilds are triggered when image SHA files are updated and merged.

## Context

PR #1077 removed these path triggers because they caused bundles to rebuild immediately when nudge PRs merged, before component images were released, resulting in validation failures. That PR relied on the `build-nudge-files` annotation to trigger rebuilds after images were successfully released.

## Changes

- Restore `"hack/konflux/images/***".pathChanged()` to `.tekton/bpfman-operator-bundle-ystream-push.yaml`
- Restore `"hack/konflux/images/***".pathChanged()` to `.tekton/bpfman-operator-bundle-zstream-push.yaml`