### PR TITLE
Test component builds trigger bundle rebuild workflow

### DIFF
--- a/cmd/test-nudging.txt
+++ b/cmd/test-nudging.txt
@@ -1,0 +1,15 @@
+This is a test file to verify that component builds (operator and agent) trigger
+the complete build chain including bundle rebuilds.
+
+When this file is modified and merged to main, it should trigger:
+1. bpfman-operator build (via "cmd/***".pathChanged())
+2. bpfman-agent build (via "cmd/***".pathChanged())
+3. Component images are built and released
+4. Image SHA files in hack/konflux/images/ are updated
+5. Bundle rebuild triggers (via "hack/konflux/images/***".pathChanged() from PR #1078)
+6. Bundle updates with new image references
+
+This validates the complete end-to-end workflow after PR #1078 restored the
+hack/konflux/images path trigger in bundle CEL expressions.
+
+Test timestamp: 2025-10-28T11:25:00Z - Part 2: Testing component → image SHA → bundle workflow


### PR DESCRIPTION
## Summary

Add `cmd/test-nudging.txt` to trigger operator and agent component builds, validating the complete end-to-end workflow after PR #1078 restored the `hack/konflux/images` path trigger.

## Test Strategy

This is **Part 2** of the test strategy (Part 1 was PR #1079).

**Expected workflow when this PR merges:**

1. Component builds trigger (operator and agent) via `"cmd/***".pathChanged()`
2. Component images build and are released
3. Image SHA files in `hack/konflux/images/` are updated by automated nudge PRs
4. Bundle rebuild triggers automatically via `"hack/konflux/images/***".pathChanged()` (restored in PR #1078)
5. Bundle updates with new image references
6. New bundle PR is created with updated image SHAs

## Test Goal

Validate that the restored `hack/konflux/images` path trigger (from PR #1078) correctly triggers bundle rebuilds when component images are updated, fixing the issue where bundle rebuilds were not happening post-merge.

## Related

- PR #1078: Restored hack/konflux/images path triggers
- PR #1079: Part 1 - Verified bundle builds work
- PR #1077: Previously removed these triggers (causing the issue)