### PR TITLE
Revert PR #1083 - Fix infinite build loop

### DIFF
--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -14,8 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-agent-zstream-push.yaml
+++ b/.tekton/bpfman-agent-zstream-push.yaml
@@ -14,8 +14,7 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman-operator.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman-operator.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Problem

PR #1083 causes an infinite build loop by adding nudge file paths to component push pipeline CEL expressions.

**The loop:**
1. Component builds → creates image `sha:ABC`
2. Automated PR updates `hack/konflux/images/component.txt` with `sha:ABC`
3. PR merges → **component CEL matches** → component rebuilds with `sha:DEF`
4. Automated PR updates to `sha:DEF`
5. **Infinite loop** 🔄

## Solution

Revert PR #1083. Components should NOT monitor their own nudge files.

## Correct Workflow (PR #1078)

The working fix is **PR #1078**, which adds `"hack/konflux/images/***".pathChanged()` to **BUNDLE pipelines only**:

1. Component builds → nudge bundle via `build-nudges-ref` relationship
2. Automated PRs update `hack/konflux/images/*.txt`
3. PRs merge → **bundle CEL matches** → bundle rebuilds (not components)
4. Bundle references correct images from .txt files
5. Releases succeed ✅

**Evidence:** Release `bpfman-ystream-zglsz-8b96df3-twqxk` succeeded with this workflow.

## What This Reverts

This reverts commit 60294c76, which added:
- `"hack/konflux/images/bpfman-operator.txt".pathChanged()` to operator push pipelines
- `"hack/konflux/images/bpfman-agent.txt".pathChanged()` to agent push pipelines

These triggers cause components to rebuild when their own image references are updated, creating the infinite loop.