### PR TITLE
Remove nudge file path triggers from component push pipelines

### DIFF
--- a/.tekton/bpfman-agent-ystream-push.yaml
+++ b/.tekton/bpfman-agent-ystream-push.yaml
@@ -14,7 +14,8 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-agent-zstream-push.yaml
+++ b/.tekton/bpfman-agent-zstream-push.yaml
@@ -14,7 +14,8 @@ metadata:
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
-      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged())
+      || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -15,7 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Summary

This fixes the infinite build loop caused by components monitoring their own nudge files in push pipeline CEL expressions.

## Problem

After PR #1083 merged, components were continuously rebuilding in a loop:
1. Component builds → creates image with SHA ABC
2. Automated PR updates hack/konflux/images/*.txt with SHA ABC
3. PR merges → component push pipeline CEL matches → component rebuilds with SHA DEF
4. Automated PR updates to SHA DEF
5. Loop continues indefinitely

## Solution

Remove nudge file path triggers from component **push** pipelines whilst retaining them in **pull-request** pipelines. This breaks the infinite loop whilst ensuring automated nudge PRs can still pass validation checks.

## Changes

- Removed `"hack/konflux/images/bpfman-operator.txt".pathChanged()` from:
  - `.tekton/bpfman-operator-ystream-push.yaml`
  - `.tekton/bpfman-operator-zstream-push.yaml`
- Removed `"hack/konflux/images/bpfman-agent.txt".pathChanged()` from:
  - `.tekton/bpfman-agent-ystream-push.yaml`
  - `.tekton/bpfman-agent-zstream-push.yaml`

## What Still Works

- Pull-request pipelines retain nudge file path triggers, enabling automated PR validation
- Bundle pipelines retain `hack/konflux/images/***` triggers, enabling bundle rebuilds when components update
- The nudge files remain in place with unchanged `build-nudge-files` annotations
- The Konflux nudging mechanism continues to function correctly