### PR TITLE
Synchronise bundle builds through operator component

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-push.yaml
@@ -13,7 +13,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged()
-      || "hack/konflux/images/***".pathChanged())
+      || "hack/konflux/images/bpfman-operator.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -13,7 +13,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged()
-      || "hack/konflux/images/***".pathChanged())
+      || "hack/konflux/images/bpfman-operator.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-operator-ystream-push.yaml
+++ b/.tekton/bpfman-operator-ystream-push.yaml
@@ -15,7 +15,8 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "OPENSHIFT-VERSION".pathChanged())
+      || "OPENSHIFT-VERSION".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -15,7 +15,8 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "OPENSHIFT-VERSION".pathChanged())
+      || "OPENSHIFT-VERSION".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Problem

Bundle builds were generating inconsistent snapshots with mismatched component versions. For example, a bundle might contain a new agent image with an old operator image, or vice versa.

## Root Cause

The previous configuration created a race condition where agent and daemon component updates triggered bundle builds directly and independently:

1. Agent builds → `bpfman-agent.txt` updated → bundle builds immediately
2. Operator also rebuilds (because operator depends on agent) → `bpfman-operator.txt` updated → bundle builds again
3. Result: Multiple bundle builds with inconsistent component versions

The issue was compounded by:
- Agent/daemon components configured to nudge the bundle directly (`build-nudges-ref: [bpfman-operator-bundle-ystream]`)
- Bundle pipeline watching wildcard `hack/konflux/images/***`, triggering on any component update

## Solution

Route all component updates through the operator pipeline before triggering bundle builds, establishing the operator as a synchronisation point.

### Pipeline Changes (this PR)

**Operator pipelines:**
- Now trigger on `hack/konflux/images/bpfman-agent.txt` changes
- Now trigger on `hack/konflux/images/bpfman.txt` changes

**Bundle pipelines:**
- Changed from wildcard `hack/konflux/images/***` to specific `hack/konflux/images/bpfman-operator.txt`

### Cluster Configuration Changes (applied manually)

The following `oc patch` commands were executed to update component nudge references:

**Before:**
```bash
# Agent components were nudging bundle directly
oc get component bpfman-agent-ystream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-bundle-ystream"]

oc get component bpfman-daemon-ystream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-bundle-ystream"]

# Same for zstream
oc get component bpfman-agent-zstream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-bundle-zstream"]

oc get component bpfman-daemon-zstream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-bundle-zstream"]
```

**Applied patches:**
```bash
# Ystream components
oc patch component bpfman-agent-ystream -n ocp-bpfman-tenant --type=json \
  -p '[{"op": "replace", "path": "/spec/build-nudges-ref", "value": ["bpfman-operator-ystream"]}]'

oc patch component bpfman-daemon-ystream -n ocp-bpfman-tenant --type=json \
  -p '[{"op": "replace", "path": "/spec/build-nudges-ref", "value": ["bpfman-operator-ystream"]}]'

# Zstream components
oc patch component bpfman-agent-zstream -n ocp-bpfman-tenant --type=json \
  -p '[{"op": "replace", "path": "/spec/build-nudges-ref", "value": ["bpfman-operator-zstream"]}]'

oc patch component bpfman-daemon-zstream -n ocp-bpfman-tenant --type=json \
  -p '[{"op": "replace", "path": "/spec/build-nudges-ref", "value": ["bpfman-operator-zstream"]}]'
```

**After:**
```bash
# Agent and daemon now nudge operator
oc get component bpfman-agent-ystream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-ystream"]

oc get component bpfman-daemon-ystream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-ystream"]

# Operator continues to nudge bundle (unchanged)
oc get component bpfman-operator-ystream -n ocp-bpfman-tenant -o jsonpath='{.spec.build-nudges-ref}'
# Output: ["bpfman-operator-bundle-ystream"]
```

## New Flow

1. **Agent or Daemon builds** → their nudge file (`bpfman-agent.txt` or `bpfman.txt`) updates
2. Nudge file change triggers **operator rebuild only** (via CEL expression + component nudge ref)
3. Operator rebuilds → `bpfman-operator.txt` updates
4. Operator.txt change triggers **single bundle build**
5. Bundle build runs `update-configmap.py` and `update-bundle.py`, reading all three synchronized nudge files

## Benefits

- Eliminates race conditions in bundle builds
- Ensures bundle always contains consistent component versions
- Reduces redundant bundle builds
- Operator becomes the synchronisation point for all component updates

## Testing

After merging, monitor that:
1. Agent/daemon updates trigger operator rebuilds
2. Operator updates trigger bundle rebuilds
3. Bundle manifests contain matching component versions