### PR TITLE
Remove wasteful bundle validation triggers for component nudge files

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -13,7 +13,6 @@ metadata:
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "hack/konflux/images/bpfman.txt".pathChanged()
       || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
-      || "hack/konflux/images/bpfman-agent.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
+      || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Summary

Remove bundle pull-request validation triggers for agent and daemon component nudge file changes to eliminate unnecessary CI time.

## Problem

When Renovate creates PRs to update `hack/konflux/images/bpfman-agent.txt` or `hack/konflux/images/bpfman.txt`, the bundle pull-request validation triggers a full bundle build that provides no meaningful validation:

1. The images are already built and validated by their own pipelines
2. The bundle contents do not change from these updates alone
3. The bundle only needs rebuilding when the operator changes

This wastes 2-3 minutes of CI time for every component nudge PR.

## Changes

**ystream-pull-request pipeline:**
- Removed `hack/konflux/images/bpfman-agent.txt` trigger
- Removed `hack/konflux/images/bpfman.txt` trigger

**zstream-pull-request pipeline:**
- Removed `hack/konflux/images/bpfman-agent.txt` trigger

## Flow Remains Correct

The push pipelines maintain the correct synchronisation flow from PR #1097:
- Operator watches `bpfman-agent.txt` and `bpfman.txt`, rebuilds when they change
- Bundle watches only `bpfman-operator.txt`, rebuilds when it changes
- This ensures consistent snapshots by routing all component updates through the operator

## Impact

Bundle PR validation will still run for changes that actually affect bundle content:
- Containerfile changes
- Bundle manifest changes
- Operator image reference changes
- Config changes
- Build pipeline changes

But will skip validation for component nudge PRs that don't affect the bundle.