### PR TITLE
Test operator and agent build nudge mechanism

### DIFF
--- a/cmd/test-nudge-trigger-operator-agent.txt
+++ b/cmd/test-nudge-trigger-operator-agent.txt
@@ -1,0 +1,21 @@
+Test operator and agent build nudge mechanism
+
+This change validates the end-to-end nudging flow for operator and agent
+components after the pipeline fixes in PR #1097.
+
+Both operator and agent build from the same source repository (bpfman-operator)
+and should trigger builds that cascade through to the bundle.
+
+Expected flow:
+1. Operator and agent build in parallel (both triggered by cmd/ change)
+2. Agent completes → nudges operator via build-nudges-ref
+3. Operator rebuild ensures synchronisation
+4. Operator nudges bundle via hack/konflux/images/bpfman-operator.txt
+5. Bundle rebuilds with all current component references
+6. Release snapshot created with consistent component versions
+
+This validates that the operator synchronisation point prevents race conditions
+where agent and operator might finish at different times, ensuring the bundle
+always builds with complete, consistent image references.
+
+Test timestamp: 2025-10-29T12:45:00Z


### PR DESCRIPTION
## Summary

This PR tests the end-to-end nudging flow for operator and agent components after the pipeline fixes in PR #1097.

A change to `cmd/` triggers both operator and agent builds from the same source repository, validating the complete synchronisation flow.

## Expected Flow

1. **Operator and agent build in parallel** (both triggered by `cmd/` change)
2. **Agent completes** → nudges operator component via `build-nudges-ref`
3. **Operator rebuilds** ensuring synchronisation (even though it was already building)
4. **Operator nudges bundle** via `hack/konflux/images/bpfman-operator.txt` update
5. **Bundle rebuilds** with all current component references (operator, agent, daemon)
6. **Release snapshot created** with consistent component versions

## Validation Goal

This validates that the operator synchronisation point prevents race conditions where agent and operator might finish at different times. The bundle should always build with complete, consistent image references.

Without the synchronisation from PR #1097, the bundle could build with:
- New agent + old operator (if agent finishes first and triggers bundle directly)
- New operator + old agent (if operator finishes first)

With PR #1097's fix, the bundle waits for both via the operator sync point.

## Related

- PR #1097: Pipeline fixes to route component updates through operator
- PR #333: Test daemon nudge (validated daemon → operator → bundle flow)
- This PR: Test operator/agent nudge (validates operator/agent → bundle flow)