### PR TITLE
Update z-stream pipelines to target release-0.5.8 branch

### DIFF
--- a/.tekton/bpfman-agent-zstream-pull-request.yaml
+++ b/.tekton/bpfman-agent-zstream-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-4.20" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-agent-zstream-pull-request.yaml".pathChanged()
+      == "release-0.5.8" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-agent-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-agent-zstream-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()

--- a/.tekton/bpfman-agent-zstream-push.yaml
+++ b/.tekton/bpfman-agent-zstream-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-4.20" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-agent-zstream-pull-request.yaml".pathChanged()
+      == "release-0.5.8" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-agent-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-agent-zstream-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-agent.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()

--- a/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-4.20" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
+      == "release-0.5.8" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()

--- a/.tekton/bpfman-operator-bundle-zstream-push.yaml
+++ b/.tekton/bpfman-operator-bundle-zstream-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-4.20" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
+      == "release-0.5.8" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-bundle-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-bundle-zstream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged()

--- a/.tekton/bpfman-operator-zstream-pull-request.yaml
+++ b/.tekton/bpfman-operator-zstream-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-4.20" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-zstream-pull-request.yaml".pathChanged()
+      == "release-0.5.8" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-zstream-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()

--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-4.20" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-zstream-pull-request.yaml".pathChanged()
+      == "release-0.5.8" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-operator-zstream-pull-request.yaml".pathChanged()
       || ".tekton/bpfman-operator-zstream-push.yaml".pathChanged() || "apis/***".pathChanged()
       || "controllers/***".pathChanged() || "cmd/***".pathChanged() || "Containerfile.bpfman-operator.openshift".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()


### PR DESCRIPTION
## Summary

Updates all z-stream Tekton pipeline definitions to target the `release-0.5.8` branch instead of `release-4.20`. This aligns the z-stream pipelines with semantic versioning conventions, following the same pattern used by network-observability-operator.

## Changes

Updated CEL expressions in all z-stream `.tekton` files:
- `bpfman-operator-zstream-push.yaml`
- `bpfman-operator-zstream-pull-request.yaml`
- `bpfman-agent-zstream-push.yaml`
- `bpfman-agent-zstream-pull-request.yaml`
- `bpfman-operator-bundle-zstream-push.yaml`
- `bpfman-operator-bundle-zstream-pull-request.yaml`

All pipelines now watch for pushes/PRs targeting `release-0.5.8` branch.

## Manual Cluster Changes Required

The corresponding Konflux Component resources were updated via `oc patch` to watch the `release-0.5.8` branch:

```bash
oc patch components bpfman-agent-zstream -n ocp-bpfman-tenant \
  --type=merge -p '{"spec":{"source":{"git":{"revision":"release-0.5.8"}}}}'

oc patch components bpfman-operator-zstream -n ocp-bpfman-tenant \
  --type=merge -p '{"spec":{"source":{"git":{"revision":"release-0.5.8"}}}}'

oc patch components bpfman-daemon-zstream -n ocp-bpfman-tenant \
  --type=merge -p '{"spec":{"source":{"git":{"revision":"release-0.5.8"}}}}'

oc patch components bpfman-operator-bundle-zstream -n ocp-bpfman-tenant \
  --type=merge -p '{"spec":{"source":{"git":{"revision":"release-0.5.8"}}}}'
```

These patches have been applied. Once this PR merges and the `release-0.5.8` branch is created, z-stream builds will trigger automatically.

## Related PRs

- openshift/bpfman#341 - Corresponding z-stream pipeline updates for bpfman daemon
- openshift/bpfman-operator#1121 - Bump version to 0.6.0 on main
- openshift/bpfman#342 - Bump version to 0.6.0 on main