### PR TITLE
Fix operator pipeline race condition by removing agent/daemon nudge triggers

### DIFF
--- a/.tekton/bpfman-operator-zstream-push.yaml
+++ b/.tekton/bpfman-operator-zstream-push.yaml
@@ -15,8 +15,7 @@ metadata:
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "pkg/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
       || "vendor/***".pathChanged() || "config/***".pathChanged() || "hack/openshift/***".pathChanged()
-      || "OPENSHIFT-VERSION".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged()
-      || "hack/konflux/images/bpfman.txt".pathChanged())
+      || "OPENSHIFT-VERSION".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Problem

The operator pipeline was triggering on changes to both:
- `hack/konflux/images/bpfman-agent.txt`
- `hack/konflux/images/bpfman.txt`

This caused race conditions where operator and agent/daemon builds would run in parallel when daemon or agent image references were updated. The result was that the bundle would often reference a stale operator image because a newer operator build completed after the bundle started building.

Example timeline of the race:
1. PR merges updating daemon image reference
2. Operator pipeline triggers (due to `bpfman.txt` in CEL expression)
3. Operator build starts with old daemon reference
4. Daemon Renovate PR merges
5. Operator build completes → creates operator image A
6. Renovate creates operator update PR with image A
7. Another daemon update happens
8. Operator pipeline triggers AGAIN
9. New operator build completes → creates operator image B
10. Bundle builds with image A reference
11. Snapshot contains image B
12. Bundle and snapshot are out of sync

## Solution

Remove the direct CEL triggers for `bpfman-agent.txt` and `bpfman.txt` from the operator pipeline. With PR #1097's build-nudge configuration, these updates already trigger operator rebuilds through the nudge mechanism by updating `bpfman-operator.txt`.

Add `hack/konflux/images/bpfman-operator.txt` as a CEL trigger to ensure the operator rebuilds when its own image reference is updated by Renovate.

The corrected synchronised build flow is:
1. Agent/daemon builds complete and update their txt files
2. Renovate merges these changes
3. Build-nudge config triggers operator rebuild
4. Operator completes and Renovate updates `bpfman-operator.txt`
5. Operator pipeline triggers on its own txt file change
6. Bundle rebuilds with correct operator reference in sync with snapshot

## Changes

- Remove `hack/konflux/images/bpfman-agent.txt` from operator CEL expression
- Remove `hack/konflux/images/bpfman.txt` from operator CEL expression  
- Add `hack/konflux/images/bpfman-operator.txt` to operator CEL expression

This prevents the "shortcut" that was bypassing the synchronisation chain whilst ensuring the operator still rebuilds when needed.