### PR TITLE
Remove unused build-image-index parameters

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -128,10 +128,6 @@ spec:
     params:
     - name: IMAGE
       value: $(params.output-image)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.image-expires-after)
     - name: ALWAYS_BUILD_INDEX
       value: $(params.build-image-index)
     - name: IMAGES


### PR DESCRIPTION
## Summary

- Remove the `COMMIT_SHA` and `IMAGE_EXPIRES_AFTER` parameters from the `build-image-index` task, as required by the [0.2 to 0.3 migration guide](https://github.com/konflux-ci/build-definitions/blob/main/task/build-image-index/0.3/MIGRATION.md).
- These parameters were never used by the task implementation.
- This is a prerequisite for #1706 which bumps the `build-image-index` task from 0.2 to 0.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pipeline configuration by streamlining parameter passing between build tasks. Removed redundant parameter wiring while maintaining existing functionality and build output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->