### PR TITLE
feat(renovate): disable github-actions bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "gomod": {
     "enabled": false
   },
+  "github-actions": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchManagers": ["pip_requirements"],


### PR DESCRIPTION
This mirrors openshift/bpfman#646 here: disable the `github-actions` Renovate manager alongside the existing `gomod` disable, so Renovate stops opening bump PRs against `.github/workflows/`. In midstream we don't drive builds from GitHub Actions -- Konflux does -- and the upstream PR cites the Mintmaker default Renovate config at https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json as reference.

Workflows do exist in this repo and recent merges include Renovate-authored action bumps (e.g. the `apache/skywalking-eyes` digest in `c16566ec`). After this change those versions will drift unless we pin them another way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration for GitHub Actions dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->