### PR TITLE
Add a Konflux operand-bump PR generator

### DIFF
--- a/hack/openshift/create-nudge-bump-pr.sh
+++ b/hack/openshift/create-nudge-bump-pr.sh
@@ -28,6 +28,11 @@
 # the authoritative base branch lives (the openshift remote), --push-remote is
 # where your branch goes (your fork). They are frequently different.
 
+# The emit calls below deliberately single-quote their arguments so that
+# $vars and $(...) reach the generated script literally and expand at its
+# runtime, not in this generator -- which is exactly what SC2016 warns
+# about, so disable it for the whole file.
+# shellcheck disable=SC2016
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -95,6 +100,12 @@ EOF
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        # Value-taking flags: fail with a clear message if the value is
+        # missing rather than tripping set -u on an unbound $2. The ;;&
+        # falls through to the specific arm below that consumes the value.
+        -b|--base|--base-remote|--push-remote|-H|--head|--repo)
+            [[ $# -ge 2 ]] || { echo "error: $1 requires a value" >&2; usage 2; }
+            ;;&
         ystream|zstream) stream="$1"; shift ;;
         -b|--base)        base="$2"; shift 2 ;;
         --base-remote)    base_remote="$2"; shift 2 ;;
@@ -125,6 +136,14 @@ fi
 
 cd "$repo_root"
 
+# The digest resolve below rewrites the image pins in place. Guarantee they
+# are restored on every exit path -- normal, error, or interrupt -- not just
+# the happy path, so a failed run never leaves the working tree modified.
+restore_nudge_dir() { git checkout --quiet -- "$nudge_dir" 2>/dev/null || true; }
+nudge_dirty=false
+trap 'if [[ "$nudge_dirty" == true ]]; then restore_nudge_dir; fi' EXIT
+trap 'exit 1' INT TERM
+
 # Resolving digests rewrites the image pins in place; refuse if they are dirty
 # so the restore below is exact. A dirty tree elsewhere is irrelevant.
 if [[ -n "$(git status --porcelain -- "$nudge_dir")" ]]; then
@@ -143,15 +162,16 @@ fi
 # reading the rewritten pins, then restoring the working tree. Send the sync's
 # own chatter to stderr so stdout stays pure script.
 echo "Resolving latest promoted digests for ${stream} from the cluster..." >&2
+nudge_dirty=true
 if ! "$sync_script" "$stream" >&2; then
     echo "error: sync-nudge-files.sh failed; is oc logged into the Konflux cluster?" >&2
-    git checkout --quiet -- "$nudge_dir" 2>/dev/null || true
-    exit 1
+    exit 1   # EXIT trap restores the nudge dir
 fi
 operator_line="$(cat "${nudge_dir}/bpfman-operator.txt")"
 agent_line="$(cat "${nudge_dir}/bpfman-agent.txt")"
 daemon_line="$(cat "${nudge_dir}/bpfman.txt")"
-git checkout --quiet -- "$nudge_dir"
+restore_nudge_dir
+nudge_dirty=false
 
 branch="nudge-bump-${stream}-${base}-$(date +%Y%m%d-%H%M%S)"
 

--- a/hack/openshift/create-nudge-bump-pr.sh
+++ b/hack/openshift/create-nudge-bump-pr.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# create-nudge-bump-pr.sh -- emit a script that opens a single PR bumping all
+# three operand images to their latest Konflux-promoted digests.
+#
+# Konflux nudges each operand bump (operator, agent, daemon) in as a separate
+# PR. Merging them one at a time lets their push pipelines race and the
+# resulting snapshot order can come out wrong, and a nudge PR is often already
+# stale by the time you merge it. This sidesteps both: it resolves the current
+# lastPromotedImage for all three components straight from the cluster and
+# writes a script that bumps them in one commit and one PR. One PR means one
+# push pipeline and one snapshot -- nothing left to order, and the digests are
+# as fresh as the cluster, not as fresh as whenever the nudge PR was cut.
+#
+# It does not touch your repo or GitHub. It prints a shell script to stdout
+# with the digests frozen in; progress goes to stderr. Redirect, read, run:
+#
+#   ./hack/openshift/create-nudge-bump-pr.sh zstream --base release-0.6 \
+#       --base-remote downstream --push-remote origin > foo.sh
+#   less foo.sh        # the digests and every git/gh command are right there
+#   bash foo.sh        # only this changes anything
+#
+# Resolving the digests reuses hack/openshift/sync-nudge-files.sh, so the same
+# prerequisite applies: oc logged into the Konflux cluster with access to the
+# ocp-bpfman-tenant namespace. The emitted script needs only git and gh.
+#
+# Remote names are per-clone, so you must name them: --base-remote is where
+# the authoritative base branch lives (the openshift remote), --push-remote is
+# where your branch goes (your fork). They are frequently different.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+sync_script="${script_dir}/sync-nudge-files.sh"
+nudge_rel="hack/konflux/images"
+nudge_dir="${repo_root}/${nudge_rel}"
+
+pr_repo="openshift/bpfman-operator"
+stream=""
+base=""
+base_remote=""
+push_remote=""
+head_owner=""
+
+usage() {
+    cat >&2 <<'EOF'
+usage: create-nudge-bump-pr.sh <ystream|zstream> --base-remote NAME \
+                               --push-remote NAME [options] > foo.sh
+
+  <ystream|zstream>     which stream to bump
+
+required:
+      --base-remote NAME  git remote holding the authoritative base branch
+                          (the openshift remote)
+      --push-remote NAME  git remote the emitted script pushes to (your fork)
+
+options:
+  -b, --base BRANCH       target branch (default: main for ystream; required
+                          for zstream, e.g. release-0.6)
+  -H, --head OWNER        owner namespace for the PR head, used as
+                          --head OWNER:branch (default: derived from the
+                          push remote's URL)
+      --repo OWNER/REPO   repository the emitted script opens the PR against
+                          (default: openshift/bpfman-operator)
+  -h, --help              this help
+
+examples:
+  The base branch lives in the openshift/bpfman-operator remote; the PR
+  pushes from your fork. With remotes named upstream (openshift) and
+  origin (your fork), that is --base-remote upstream --push-remote origin.
+  (A separate bpfman remote for bpfman/bpfman-operator is not used here.)
+
+  # ystream: bump main
+  create-nudge-bump-pr.sh ystream \
+      --base-remote upstream --push-remote origin > bump.sh
+
+  # zstream: bump a release branch (--base is required)
+  create-nudge-bump-pr.sh zstream --base release-0.6 \
+      --base-remote upstream --push-remote origin > bump.sh
+
+  # then review the emitted script and run it
+  less bump.sh
+  bash bump.sh
+
+The script is written to stdout; redirect it, read it, then run it. Nothing
+here touches your repo or GitHub -- only running the emitted script does.
+
+prerequisites:
+  - run from a bpfman-operator checkout with hack/konflux/images clean
+  - oc logged into the Konflux cluster (ocp-bpfman-tenant) for the digest lookup
+EOF
+    exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        ystream|zstream) stream="$1"; shift ;;
+        -b|--base)        base="$2"; shift 2 ;;
+        --base-remote)    base_remote="$2"; shift 2 ;;
+        --push-remote)    push_remote="$2"; shift 2 ;;
+        -H|--head)        head_owner="$2"; shift 2 ;;
+        --repo)           pr_repo="$2"; shift 2 ;;
+        -h|--help)        usage 0 ;;
+        *) echo "unknown argument: $1" >&2; usage 2 ;;
+    esac
+done
+
+[[ -n "$stream" ]]      || { echo "error: stream (ystream|zstream) is required" >&2; usage 2; }
+[[ -n "$base_remote" ]] || { echo "error: --base-remote is required" >&2; usage 2; }
+[[ -n "$push_remote" ]] || { echo "error: --push-remote is required" >&2; usage 2; }
+
+# ystream tracks main; zstream tracks a specific release branch, and there can
+# be more than one active, so do not guess it.
+if [[ -z "$base" ]]; then
+    if [[ "$stream" == "ystream" ]]; then
+        base="main"
+    else
+        echo "error: zstream needs an explicit --base (e.g. release-0.6)" >&2
+        exit 2
+    fi
+fi
+
+[[ -x "$sync_script" ]] || { echo "error: $sync_script not found or not executable" >&2; exit 1; }
+
+cd "$repo_root"
+
+# Resolving digests rewrites the image pins in place; refuse if they are dirty
+# so the restore below is exact. A dirty tree elsewhere is irrelevant.
+if [[ -n "$(git status --porcelain -- "$nudge_dir")" ]]; then
+    echo "error: uncommitted changes under ${nudge_rel}; commit or stash first" >&2
+    exit 1
+fi
+
+# Default the PR head owner to whoever owns the push remote.
+if [[ -z "$head_owner" ]]; then
+    head_owner="$(git remote get-url "$push_remote" \
+        | sed -E 's#\.git$##; s#.*[:/]([^/]+)/[^/]+$#\1#')"
+    [[ -n "$head_owner" ]] || { echo "error: could not derive head owner from ${push_remote}; pass --head" >&2; exit 1; }
+fi
+
+# Resolve the three digests by running the existing sync against the cluster,
+# reading the rewritten pins, then restoring the working tree. Send the sync's
+# own chatter to stderr so stdout stays pure script.
+echo "Resolving latest promoted digests for ${stream} from the cluster..." >&2
+if ! "$sync_script" "$stream" >&2; then
+    echo "error: sync-nudge-files.sh failed; is oc logged into the Konflux cluster?" >&2
+    git checkout --quiet -- "$nudge_dir" 2>/dev/null || true
+    exit 1
+fi
+operator_line="$(cat "${nudge_dir}/bpfman-operator.txt")"
+agent_line="$(cat "${nudge_dir}/bpfman-agent.txt")"
+daemon_line="$(cat "${nudge_dir}/bpfman.txt")"
+git checkout --quiet -- "$nudge_dir"
+
+branch="nudge-bump-${stream}-${base}-$(date +%Y%m%d-%H%M%S)"
+
+commit_title="Bump ${stream} operand images to latest promoted digests"
+commit_body="Set bpfman-operator, bpfman-agent and bpfman-daemon to their current
+Konflux lastPromotedImage for the ${stream} stream, replacing the individual
+konflux-nudge PRs with one deterministic bump so a single push pipeline
+produces a single consistent snapshot."
+
+pr_body="Consolidated ${stream} operand bump: bpfman-operator, bpfman-agent and
+bpfman-daemon set to their current Konflux lastPromotedImage, resolved from the
+cluster rather than from the individual konflux-nudge PRs. One PR means one push
+pipeline and one snapshot, so there is no merge order to get wrong, and the
+digests are current as of PR creation. This is the manual replacement for
+per-operand Konflux nudging."
+
+# Everything from here is the emitted script, on stdout.
+emit() { printf '%s\n' "$1"; }
+
+emit '#!/usr/bin/env bash'
+emit "# Bump ${stream} operand images to their latest Konflux-promoted digests."
+emit "# Generated by hack/openshift/create-nudge-bump-pr.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)."
+emit '# Review the digests and commands below, then run with: bash foo.sh'
+emit 'set -euo pipefail'
+emit ''
+emit '# Operand pins are written under hack/konflux/images using paths relative'
+emit '# to the repository root, so this must run from there.'
+emit 'toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || {'
+emit "    echo 'error: not inside a git repository.' >&2"
+emit '    exit 1'
+emit '}'
+emit 'if [[ ! "$PWD" -ef "$toplevel" ]]; then'
+emit '    echo "error: run this from the repository root: cd $toplevel" >&2'
+emit '    exit 1'
+emit 'fi'
+emit ''
+emit 'start_ref="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"'
+emit "git fetch ${base_remote} ${base}"
+emit "git checkout -b ${branch} FETCH_HEAD"
+emit ''
+emit "printf '%s\\n' '${operator_line}' > ${nudge_rel}/bpfman-operator.txt"
+emit "printf '%s\\n' '${agent_line}' > ${nudge_rel}/bpfman-agent.txt"
+emit "printf '%s\\n' '${daemon_line}' > ${nudge_rel}/bpfman.txt"
+emit "git add ${nudge_rel}"
+emit ''
+emit 'if git diff --cached --quiet; then'
+emit "    echo 'Already at the latest promoted digests; nothing to bump.' >&2"
+emit '    git checkout --quiet "$start_ref" 2>/dev/null || true'
+emit "    git branch -D ${branch} >/dev/null 2>&1 || true"
+emit '    exit 0'
+emit 'fi'
+emit ''
+emit "git commit -m '${commit_title}' -m '${commit_body}'"
+emit "git push ${push_remote} ${branch}"
+emit "gh pr create --repo ${pr_repo} --base ${base} --head ${head_owner}:${branch} \\"
+emit "    --title '${commit_title}' \\"
+emit "    --body '${pr_body}'"
+
+echo "Wrote bump script to stdout (branch ${branch}). Redirect it to a file, review, then run it." >&2


### PR DESCRIPTION
Konflux nudges each operand image bump -- bpfman-operator, bpfman-agent, bpfman-daemon -- in as a separate PR. Merging them one at a time lets their push pipelines race, so the resulting snapshot order can come out wrong, and any one nudge PR is often already stale by the time it merges. `hack/openshift/create-nudge-bump-pr.sh` consolidates that: it resolves the current `lastPromotedImage` for all three components straight from the Konflux cluster and emits a script that bumps them in a single commit and a single PR, so there is one push pipeline and one consistent snapshot with no merge order to get wrong, and digests that are current as of when you run it.

Running the generator is non-destructive. It does not touch the repository or GitHub: it only resolves the digests and prints a self-contained bump script to stdout, with progress on stderr. You redirect that to a file, inspect it -- the digests and every git and gh command are right there -- and only then run it. The emitted script is the single thing that changes anything. It also guards that it runs from the repository root (the image pins are written with repo-root-relative paths), starts the bump from the authoritative base branch you name, and no-ops cleanly when the pins are already at the latest digests.

The two remote arguments are taken explicitly rather than guessed, because remote names vary per clone. `--base-remote` is the remote pointing at `openshift/bpfman-operator` (where the authoritative base branch lives), and `--push-remote` is your fork (where the PR branch is pushed from). In the examples below these are `upstream` and `origin`; substitute your own remote names if they differ -- for instance a clone where the openshift repo is named `downstream` would use `--base-remote downstream`.

## Example

Generating the script changes nothing; it just writes the bump script to stdout with the digests frozen in. Here `--base-remote upstream` is the remote for `openshift/bpfman-operator` and `--push-remote origin` is your fork:

```console
$ ./hack/openshift/create-nudge-bump-pr.sh ystream --base-remote upstream --push-remote origin > foo.sh
Resolving latest promoted digests for ystream from the cluster...
Wrote bump script to stdout (branch nudge-bump-ystream-main-20260619-114942). Redirect it to a file, review, then run it.
```

You then read `foo.sh` before running anything. A representative emitted script:

```bash
#!/usr/bin/env bash
# Bump ystream operand images to their latest Konflux-promoted digests.
# Generated by hack/openshift/create-nudge-bump-pr.sh on 2026-06-19T10:49:42Z.
# Review the digests and commands below, then run with: bash foo.sh
set -euo pipefail

# Operand pins are written under hack/konflux/images using paths relative
# to the repository root, so this must run from there.
toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || {
    echo 'error: not inside a git repository.' >&2
    exit 1
}
if [[ ! "$PWD" -ef "$toplevel" ]]; then
    echo "error: run this from the repository root: cd $toplevel" >&2
    exit 1
fi

start_ref="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
git fetch upstream main
git checkout -b nudge-bump-ystream-main-20260619-114942 FETCH_HEAD

printf '%s\n' 'registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:87d5ec68794c792f54114b1f88d0d12fdbd3c9e8b7a2792b7a449e6aea4c9a09' > hack/konflux/images/bpfman-operator.txt
printf '%s\n' 'registry.redhat.io/bpfman/bpfman-agent@sha256:75e57f7e9f40f6442f0c9f5b35988c689f335d30f1a6467420de4feab61ee7a3' > hack/konflux/images/bpfman-agent.txt
printf '%s\n' 'registry.redhat.io/bpfman/bpfman@sha256:8a3d8aa64fc868805d8081444be0e0bac4e39cee80f1bf1b3b679a7c7a64a022' > hack/konflux/images/bpfman.txt
git add hack/konflux/images

if git diff --cached --quiet; then
    echo 'Already at the latest promoted digests; nothing to bump.' >&2
    git checkout --quiet "$start_ref" 2>/dev/null || true
    git branch -D nudge-bump-ystream-main-20260619-114942 >/dev/null 2>&1 || true
    exit 0
fi

git commit -m 'Bump ystream operand images to latest promoted digests' -m '...'
git push origin nudge-bump-ystream-main-20260619-114942
gh pr create --repo openshift/bpfman-operator --base main --head frobware:nudge-bump-ystream-main-20260619-114942 \
    --title 'Bump ystream operand images to latest promoted digests' \
    --body '...'
```

The `git fetch upstream main` and `git push origin ...` lines are exactly the `--base-remote` and `--push-remote` values you passed. Only `bash foo.sh` changes anything, and if the pins are already current it prints "nothing to bump" and restores your starting branch without creating a PR.

## Test plan

From the repository root with `oc` logged into the Konflux cluster (ocp-bpfman-tenant), using your remote for `openshift/bpfman-operator` as `--base-remote` and your fork as `--push-remote`:

    ./hack/openshift/create-nudge-bump-pr.sh ystream --base-remote upstream --push-remote origin > foo.sh
    less foo.sh
    bash foo.sh

Exercised end to end against a clean tree: the generator resolves the three digests, the emitted script fetches the base from the openshift remote, writes the pins, and when they are already current reports nothing to bump and restores the starting branch. The generator passes `bash -n`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new automation script that streamlines the process of resolving image digests and automatically generating pull requests for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->