### PR TITLE
BPFMAN-31: Cherry-pick upstream PRs #530 and #536

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,11 +337,16 @@ test-integration-local: ## Run Integration tests against existing deployment. Us
 	SKIP_BPFMAN_DEPLOY=true \
 	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration $(if $(TEST),-run $(TEST),)
 
+# Default go test timeout for the OpenShift suite. The full suite is slow on a
+# multi-node cluster (cosign-verified image pulls across every node), so the
+# 10m go test default is not enough. Override with TEST_TIMEOUT=.
+TEST_TIMEOUT ?= 60m
+
 .PHONY: test-integration-openshift
-test-integration-openshift: ## Run Integration tests against the OpenShift cluster in the current kubeconfig context (assumes bpfman is already deployed). Use TEST= to specify test pattern.
+test-integration-openshift: ## Run Integration tests against the OpenShift cluster in the current kubeconfig context (assumes bpfman is already deployed). Use TEST= for a pattern and TEST_TIMEOUT= to override the go test timeout.
 	USE_EXISTING_CLUSTER=true \
 	SKIP_BPFMAN_DEPLOY=true \
-	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration $(if $(TEST),-run $(TEST),)
+	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v -timeout $(TEST_TIMEOUT) ./test/integration $(if $(TEST),-run $(TEST),)
 
 .PHONY: test-lifecycle-local
 test-lifecycle-local: ## Run lifecycle tests against existing deployment.

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,12 @@ test-integration-local: ## Run Integration tests against existing deployment. Us
 	SKIP_BPFMAN_DEPLOY=true \
 	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration $(if $(TEST),-run $(TEST),)
 
+.PHONY: test-integration-openshift
+test-integration-openshift: ## Run Integration tests against the OpenShift cluster in the current kubeconfig context (assumes bpfman is already deployed). Use TEST= to specify test pattern.
+	USE_EXISTING_CLUSTER=true \
+	SKIP_BPFMAN_DEPLOY=true \
+	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration $(if $(TEST),-run $(TEST),)
+
 .PHONY: test-lifecycle-local
 test-lifecycle-local: ## Run lifecycle tests against existing deployment.
 	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/lifecycle

--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ test-integration-local: ## Run Integration tests against existing deployment. Us
 TEST_TIMEOUT ?= 60m
 
 .PHONY: test-integration-openshift
-test-integration-openshift: ## Run Integration tests against the OpenShift cluster in the current kubeconfig context (assumes bpfman is already deployed). Use TEST= for a pattern and TEST_TIMEOUT= to override the go test timeout.
+test-integration-openshift: ## Run Integration tests against the OpenShift cluster in the current kubeconfig context (assumes bpfman and the security-profiles-operator are already deployed). Use TEST= for a pattern and TEST_TIMEOUT= to override the go test timeout.
 	USE_EXISTING_CLUSTER=true \
 	SKIP_BPFMAN_DEPLOY=true \
 	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v -timeout $(TEST_TIMEOUT) ./test/integration $(if $(TEST),-run $(TEST),)

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -18,6 +18,7 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	bpfmanclientset "github.com/bpfman/bpfman-operator/pkg/client/clientset"
@@ -101,8 +102,9 @@ func (t TcProgramDirection) String() string {
 
 var log = ctrl.Log.WithName("bpfman-helpers")
 
-// getk8sConfig gets a kubernetes config automatically detecting if it should
-// be the in or out of cluster config. If this step fails panic.
+// GetK8sConfigOrDie gets a kubernetes config automatically detecting if it should
+// be the in or out of cluster config. When running in-cluster, KUBECONFIG
+// env var takes precedence over the in-cluster config. If this step fails panic.
 func GetK8sConfigOrDie() *rest.Config {
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -115,7 +117,16 @@ func GetK8sConfigOrDie() *rest.Config {
 
 		log.Info("Program running from outside of the cluster, picking config from --kubeconfig flag")
 	} else {
-		log.Info("Program running inside the cluster, picking the in-cluster configuration")
+		kubeConfig := os.Getenv("KUBECONFIG")
+		if kubeConfig != "" {
+			config, err = clientcmd.BuildConfigFromFlags("", kubeConfig)
+			if err != nil {
+				panic(err)
+			}
+			log.Info("Program running inside the cluster, picking config from KUBECONFIG env var")
+		} else {
+			log.Info("Program running inside the cluster, picking the in-cluster configuration")
+		}
 	}
 
 	return config

--- a/test/integration/app_test.go
+++ b/test/integration/app_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ func TestApplicationGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), targetUserspaceNs, targetKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up target program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(targetKustomize))
+		return deleteWorkload(ctx, env.Cluster(), targetKustomize)
 	})
 
 	t.Log("waiting for go target userspace daemon to be available")
@@ -44,7 +43,7 @@ func TestApplicationGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), appGoCounterUserspaceNs, appGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up application counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(appGoCounterKustomize))
+		return deleteWorkload(ctx, env.Cluster(), appGoCounterKustomize)
 	})
 
 	t.Log("waiting for application counter BPF program to be loaded")

--- a/test/integration/app_test.go
+++ b/test/integration/app_test.go
@@ -26,6 +26,10 @@ const (
 func TestApplicationGoCounter(t *testing.T) {
 	t.Log("deploying target required for uprobe counter program if its not already deployed")
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), targetUserspaceNs, targetKustomize))
+	addCleanup(func(context.Context) error {
+		cleanupLog("cleaning up target program")
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(targetKustomize))
+	})
 
 	t.Log("waiting for go target userspace daemon to be available")
 	require.Eventually(t, func() bool {

--- a/test/integration/app_test.go
+++ b/test/integration/app_test.go
@@ -25,7 +25,7 @@ const (
 
 func TestApplicationGoCounter(t *testing.T) {
 	t.Log("deploying target required for uprobe counter program if its not already deployed")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), targetKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), targetUserspaceNs, targetKustomize))
 
 	t.Log("waiting for go target userspace daemon to be available")
 	require.Eventually(t, func() bool {
@@ -37,10 +37,10 @@ func TestApplicationGoCounter(t *testing.T) {
 		5*time.Minute, 10*time.Second)
 
 	t.Log("deploying application counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), appGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), appGoCounterUserspaceNs, appGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up application counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), appGoCounterKustomize)
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(appGoCounterKustomize))
 	})
 
 	t.Log("waiting for application counter BPF program to be loaded")

--- a/test/integration/common.go
+++ b/test/integration/common.go
@@ -11,11 +11,21 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bpfman/bpfman-operator/apis/v1alpha1"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
@@ -367,4 +377,167 @@ func verifyLinkOrder(links []link) bool {
 		oldI = i
 	}
 	return true
+}
+
+// podExec runs a command in a pod and captures stdout/stderr.
+func podExec(ctx context.Context, t *testing.T, pod corev1.Pod, container string, stdout, stderr *bytes.Buffer, cmd []string) error {
+	t.Helper()
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		t.Fatalf("failed to get kube config: %v", err)
+	}
+
+	cl, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("failed to create kube client: %v", err)
+	}
+
+	req := cl.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec")
+
+	execOptions := &corev1.PodExecOptions{
+		Command: cmd,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     false,
+	}
+	if container != "" {
+		execOptions.Container = container
+	}
+
+	req.VersionedParams(execOptions, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(kubeConfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	return exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}
+
+// deployWorkload applies an example kustomization and, on an existing
+// (OpenShift) cluster, reconciles the SELinux type the workload requests with
+// the one the security-profiles-operator actually installed (see
+// alignWorkloadSelinuxType). On kind it is a plain kustomize apply.
+func deployWorkload(ctx context.Context, cluster clusters.Cluster, namespace, kustomizeURL string) error {
+	if err := clusters.KustomizeDeployForCluster(ctx, cluster, workloadKustomize(kustomizeURL)); err != nil {
+		return err
+	}
+	return alignWorkloadSelinuxType(ctx, cluster, namespace)
+}
+
+// workloadKustomize selects the example kustomize overlay for the current
+// cluster. On an existing (OpenShift) cluster it swaps the default overlay for
+// the selinux one, which labels the namespace privileged, binds the workload
+// serviceaccount to the bpfman-restricted SCC, and installs a SelinuxProfile
+// granting the userspace consumer bpf map access -- the combination the
+// example workloads need under enforcing SELinux. That overlay relies on the
+// security-profiles-operator being installed (see the SelinuxProfile check in
+// TestMain). On kind the default overlay is used unchanged.
+func workloadKustomize(defaultURL string) string {
+	if !useExistingCluster {
+		return defaultURL
+	}
+	return strings.Replace(defaultURL, "/config/default/", "/config/selinux/", 1)
+}
+
+// selinuxProfileGVR is the security-profiles-operator SelinuxProfile resource.
+var selinuxProfileGVR = schema.GroupVersionResource{
+	Group:    "security-profiles-operator.x-k8s.io",
+	Version:  "v1alpha2",
+	Resource: "selinuxprofiles",
+}
+
+// alignWorkloadSelinuxType points each workload daemonset at the SELinux type
+// the security-profiles-operator actually installed. The selinux example
+// overlay hardcodes the older <profile>_<namespace>.process naming, but newer
+// SPO names the type <profile>.process and records the real value in the
+// SelinuxProfile's status.usage. When the two disagree the container runtime
+// rejects the unknown label ("write to /proc/self/attr/keycreate: Invalid
+// argument") and no pods start, so we rewrite the daemonsets' seLinuxOptions
+// type to the installed one. It is a no-op on kind and whenever the requested
+// type already matches.
+func alignWorkloadSelinuxType(ctx context.Context, cluster clusters.Cluster, namespace string) error {
+	if !useExistingCluster {
+		return nil
+	}
+
+	// Find the daemonset containers whose SELinux type the overlay pinned.
+	// Some workloads (e.g. go-target) ship no SelinuxProfile and set no
+	// type, so there is nothing to reconcile and no profile to wait for.
+	daemonsets, err := cluster.Client().AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing daemonsets in %s: %w", namespace, err)
+	}
+	type target struct{ daemonset, container, current string }
+	var targets []target
+	for i := range daemonsets.Items {
+		ds := &daemonsets.Items[i]
+		for _, c := range ds.Spec.Template.Spec.Containers {
+			if sc := c.SecurityContext; sc != nil && sc.SELinuxOptions != nil && sc.SELinuxOptions.Type != "" {
+				targets = append(targets, target{ds.Name, c.Name, sc.SELinuxOptions.Type})
+			}
+		}
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	dyn, err := dynamic.NewForConfig(cluster.Config())
+	if err != nil {
+		return fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	for _, t := range targets {
+		// The overlay pins the type to <profile>_<namespace>.process. If it
+		// is not in that form it is already aligned (or doesn't reference a
+		// profile), so leave it.
+		suffix := "_" + namespace + ".process"
+		if !strings.HasSuffix(t.current, suffix) {
+			continue
+		}
+		profileName := strings.TrimSuffix(t.current, suffix)
+
+		// SelinuxProfile is cluster-scoped in current SPO; wait for it to
+		// report the type it actually installed, which appears soon after
+		// the overlay creates it and before it reaches the Installed state.
+		var usage string
+		for i := 0; i < 24 && usage == ""; i++ {
+			profiles, err := dyn.Resource(selinuxProfileGVR).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("listing selinuxprofiles: %w", err)
+			}
+			for _, p := range profiles.Items {
+				if p.GetName() == profileName {
+					usage, _, _ = unstructured.NestedString(p.Object, "status", "usage")
+					break
+				}
+			}
+			if usage == "" {
+				time.Sleep(5 * time.Second)
+			}
+		}
+		if usage == "" {
+			return fmt.Errorf("SelinuxProfile %s reported no usage type", profileName)
+		}
+		if usage == t.current {
+			continue
+		}
+
+		patch := fmt.Sprintf(
+			`{"spec":{"template":{"spec":{"containers":[{"name":%q,"securityContext":{"seLinuxOptions":{"type":%q}}}]}}}}`,
+			t.container, usage)
+		if _, err := cluster.Client().AppsV1().DaemonSets(namespace).Patch(ctx, t.daemonset, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("aligning SELinux type on daemonset %s/%s: %w", namespace, t.daemonset, err)
+		}
+	}
+
+	return nil
 }

--- a/test/integration/common.go
+++ b/test/integration/common.go
@@ -433,6 +433,14 @@ func deployWorkload(ctx context.Context, cluster clusters.Cluster, namespace, ku
 	return alignWorkloadSelinuxType(ctx, cluster, namespace)
 }
 
+// deleteWorkload removes an example kustomization. It passes --ignore-not-found
+// so teardown is idempotent: the selinux overlays share one cluster-scoped
+// SelinuxProfile (bpfman-secure), and go-target is deployed by more than one
+// test, so a resource may already have been removed by an earlier cleanup.
+func deleteWorkload(ctx context.Context, cluster clusters.Cluster, kustomizeURL string) error {
+	return clusters.KustomizeDeleteForCluster(ctx, cluster, workloadKustomize(kustomizeURL), "--ignore-not-found")
+}
+
 // workloadKustomize selects the example kustomize overlay for the current
 // cluster. On an existing (OpenShift) cluster it swaps the default overlay for
 // the selinux one, which labels the namespace privileged, binds the workload

--- a/test/integration/existingcluster.go
+++ b/test/integration/existingcluster.go
@@ -1,0 +1,141 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+// existingClusterType marks a cluster that the suite attached to
+// rather than provisioned, and therefore must never tear down.
+const existingClusterType clusters.Type = "existing"
+
+// existingCluster is a clusters.Cluster backed by whatever cluster the
+// caller's kubeconfig already points at (KUBECONFIG plus current
+// context). Unlike the kind-backed path it issues no kind or container
+// commands, so it works against any reachable cluster -- in particular
+// an OpenShift cluster reached via `oc login`.
+type existingCluster struct {
+	name   string
+	client *kubernetes.Clientset
+	cfg    *rest.Config
+	addons clusters.Addons
+}
+
+// newExistingCluster builds a cluster from the ambient kubeconfig,
+// using the same loading rules as the bpfman client so that both
+// resolve to the same current context.
+func newExistingCluster() (*existingCluster, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
+
+	raw, err := cc.RawConfig()
+	if err != nil {
+		return nil, fmt.Errorf("reading kubeconfig: %w", err)
+	}
+
+	cfg, err := cc.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("building rest config: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("building clientset: %w", err)
+	}
+
+	return &existingCluster{
+		name:   raw.CurrentContext,
+		client: client,
+		cfg:    cfg,
+		addons: make(clusters.Addons),
+	}, nil
+}
+
+func (c *existingCluster) Name() string {
+	return c.name
+}
+
+func (c *existingCluster) Type() clusters.Type {
+	return existingClusterType
+}
+
+func (c *existingCluster) Version() (semver.Version, error) {
+	versionInfo, err := c.client.ServerVersion()
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return semver.Parse(strings.TrimPrefix(versionInfo.String(), "v"))
+}
+
+func (c *existingCluster) Client() *kubernetes.Clientset {
+	return c.client
+}
+
+func (c *existingCluster) Config() *rest.Config {
+	return c.cfg
+}
+
+// Cleanup is a no-op: the suite did not create this cluster, so it has
+// no business deleting it.
+func (c *existingCluster) Cleanup(context.Context) error {
+	return nil
+}
+
+func (c *existingCluster) GetAddon(name clusters.AddonName) (clusters.Addon, error) {
+	addon, ok := c.addons[name]
+	if !ok {
+		return nil, fmt.Errorf("addon %s not found", name)
+	}
+	return addon, nil
+}
+
+func (c *existingCluster) ListAddons() []clusters.Addon {
+	addonList := make([]clusters.Addon, 0, len(c.addons))
+	for _, addon := range c.addons {
+		addonList = append(addonList, addon)
+	}
+	return addonList
+}
+
+func (c *existingCluster) DeployAddon(ctx context.Context, addon clusters.Addon) error {
+	if _, ok := c.addons[addon.Name()]; ok {
+		return fmt.Errorf("addon component %s is already loaded into cluster %s", addon.Name(), c.name)
+	}
+	c.addons[addon.Name()] = addon
+	return addon.Deploy(ctx, c)
+}
+
+func (c *existingCluster) DeleteAddon(ctx context.Context, addon clusters.Addon) error {
+	if _, ok := c.addons[addon.Name()]; !ok {
+		return nil
+	}
+	if err := addon.Delete(ctx, c); err != nil {
+		return err
+	}
+	delete(c.addons, addon.Name())
+	return nil
+}
+
+func (c *existingCluster) DumpDiagnostics(ctx context.Context, meta string) (string, error) {
+	outDir, err := os.MkdirTemp(os.TempDir(), clusters.DiagnosticOutDirectoryPrefix)
+	if err != nil {
+		return "", err
+	}
+	return outDir, clusters.DumpDiagnostics(ctx, c, meta, outDir)
+}
+
+func (c *existingCluster) IPFamily() clusters.IPFamily {
+	return clusters.IPv4
+}

--- a/test/integration/kprobe_test.go
+++ b/test/integration/kprobe_test.go
@@ -25,10 +25,10 @@ const (
 
 func TestKprobeGoCounter(t *testing.T) {
 	t.Log("deploying kprobe counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), kprobeGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), kprobeGoCounterUserspaceNs, kprobeGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up kprobe counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), kprobeGoCounterKustomize)
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(kprobeGoCounterKustomize))
 	})
 
 	t.Log("waiting for kprobe counter BPF program to be loaded")

--- a/test/integration/kprobe_test.go
+++ b/test/integration/kprobe_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ func TestKprobeGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), kprobeGoCounterUserspaceNs, kprobeGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up kprobe counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(kprobeGoCounterKustomize))
+		return deleteWorkload(ctx, env.Cluster(), kprobeGoCounterKustomize)
 	})
 
 	t.Log("waiting for kprobe counter BPF program to be loaded")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -38,8 +38,11 @@ var (
 	bpfmanAgentImage    = os.Getenv("BPFMAN_AGENT_IMG")
 	bpfmanOperatorImage = os.Getenv("BPFMAN_OPERATOR_IMG")
 
-	existingCluster      = os.Getenv("USE_EXISTING_KIND_CLUSTER")
-	keepTestCluster      = func() bool { return os.Getenv("TEST_KEEP_CLUSTER") == "true" || existingCluster != "" }()
+	existingKindCluster = os.Getenv("USE_EXISTING_KIND_CLUSTER")
+	useExistingCluster  = os.Getenv("USE_EXISTING_CLUSTER") == "true"
+	keepTestCluster     = func() bool {
+		return os.Getenv("TEST_KEEP_CLUSTER") == "true" || existingKindCluster != "" || useExistingCluster
+	}()
 	keepKustomizeDeploys = func() bool { return os.Getenv("TEST_KEEP_KUSTOMIZE_DEPLOYS") == "true" }()
 	skipBpfmanDeploy     = func() bool { return os.Getenv("SKIP_BPFMAN_DEPLOY") == "true" }()
 
@@ -60,46 +63,58 @@ const (
 func TestMain(m *testing.M) {
 	logf.SetLogger(zap.New())
 
-	ociBin := os.Getenv("OCI_BIN")
-	if ociBin == "" {
-		ociBin = "docker" // default if OCI_BIN is not set.
-	}
-
-	// check that we have the bpfman-agent, and bpfman-operator images to use for the tests.
-	// generally the runner of the tests should have built these from the latest
-	// changes prior to the tests and fed them to the test suite.
-	if bpfmanAgentImage == "" || bpfmanOperatorImage == "" {
-		exitOnErr(fmt.Errorf("BPFMAN_AGENT_IMG, and BPFMAN_OPERATOR_IMG must be provided"))
-	} else {
-		fmt.Printf("INFO: using bpfmanAgentImage=%s and bpfmanOperatorImage=%s\n", bpfmanAgentImage, bpfmanOperatorImage)
-	}
-
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
-	// to use the provided bpfman-agent, and bpfman-operator images we will need to add
-	// them as images to load in the test cluster via an addon.
-	fmt.Println("INFO: Loading images")
-	loadImages, err := loadimagearchive.NewBuilder(ociBin).WithImage(bpfmanAgentImage)
-	exitOnErr(err)
-	loadImages, err = loadImages.WithImage(bpfmanOperatorImage)
-	exitOnErr(err)
-
-	if existingCluster != "" {
-		fmt.Printf("INFO: existing kind cluster %s was provided\n", existingCluster)
-
-		// if an existing cluster was provided, build a test env out of that instead
-		cluster, err := kind.NewFromExisting(existingCluster)
+	if useExistingCluster {
+		// An existing, non-kind cluster -- e.g. OpenShift reached via
+		// `oc login`. Its images come from a registry the cluster can
+		// already pull from, so the kind image-load addon does not
+		// apply and the operator/agent image env vars are not needed.
+		fmt.Println("INFO: using the existing cluster from the current kubeconfig context")
+		cluster, err := newExistingCluster()
 		exitOnErr(err)
-		env, err = environments.NewBuilder().WithAddons(loadImages.Build()).WithExistingCluster(cluster).Build(ctx)
+		fmt.Printf("INFO: attached to existing cluster (context %q)\n", cluster.Name())
+		env, err = environments.NewBuilder().WithExistingCluster(cluster).Build(ctx)
 		exitOnErr(err)
 	} else {
-		fmt.Println("INFO: creating a new kind cluster")
-		// create the testing environment and cluster
-		env, err = environments.NewBuilder().WithAddons(loadImages.Build()).Build(ctx)
+		// check that we have the bpfman-agent, and bpfman-operator images to use for the tests.
+		// generally the runner of the tests should have built these from the latest
+		// changes prior to the tests and fed them to the test suite.
+		if bpfmanAgentImage == "" || bpfmanOperatorImage == "" {
+			exitOnErr(fmt.Errorf("BPFMAN_AGENT_IMG, and BPFMAN_OPERATOR_IMG must be provided"))
+		}
+		fmt.Printf("INFO: using bpfmanAgentImage=%s and bpfmanOperatorImage=%s\n", bpfmanAgentImage, bpfmanOperatorImage)
+
+		ociBin := os.Getenv("OCI_BIN")
+		if ociBin == "" {
+			ociBin = "docker" // default if OCI_BIN is not set.
+		}
+
+		// to use the provided bpfman-agent, and bpfman-operator images we will need to add
+		// them as images to load in the test cluster via an addon.
+		fmt.Println("INFO: Loading images")
+		loadImages, err := loadimagearchive.NewBuilder(ociBin).WithImage(bpfmanAgentImage)
+		exitOnErr(err)
+		loadImages, err = loadImages.WithImage(bpfmanOperatorImage)
 		exitOnErr(err)
 
-		fmt.Printf("INFO: new kind cluster %s was created\n", env.Cluster().Name())
+		if existingKindCluster != "" {
+			fmt.Printf("INFO: existing kind cluster %s was provided\n", existingKindCluster)
+
+			// if an existing cluster was provided, build a test env out of that instead
+			cluster, err := kind.NewFromExisting(existingKindCluster)
+			exitOnErr(err)
+			env, err = environments.NewBuilder().WithAddons(loadImages.Build()).WithExistingCluster(cluster).Build(ctx)
+			exitOnErr(err)
+		} else {
+			fmt.Println("INFO: creating a new kind cluster")
+			// create the testing environment and cluster
+			env, err = environments.NewBuilder().WithAddons(loadImages.Build()).Build(ctx)
+			exitOnErr(err)
+
+			fmt.Printf("INFO: new kind cluster %s was created\n", env.Cluster().Name())
+		}
 	}
 
 	if !keepTestCluster {
@@ -112,16 +127,28 @@ func TestMain(m *testing.M) {
 	fmt.Println("INFO: Get the bpfman client")
 	bpfmanClient = bpfmanHelpers.GetClientOrDie()
 
-	// Detect whether the monitoring.coreos.com API group is present.
+	// Detect optional API groups: monitoring.coreos.com (metrics-proxy) and
+	// security-profiles-operator.x-k8s.io (needed on an existing OpenShift
+	// cluster for the example workloads' SELinux profiles).
 	apiList, err := env.Cluster().Client().Discovery().ServerGroups()
 	exitOnErr(err)
+	var hasSelinuxProfiles bool
 	for _, g := range apiList.Groups {
-		if g.Name == "monitoring.coreos.com" {
+		switch g.Name {
+		case "monitoring.coreos.com":
 			hasMonitoring = true
-			break
+		case "security-profiles-operator.x-k8s.io":
+			hasSelinuxProfiles = true
 		}
 	}
 	fmt.Printf("INFO: hasMonitoring=%v\n", hasMonitoring)
+
+	// On an existing cluster the workloads use the selinux example overlay,
+	// which ships SelinuxProfile resources; the security-profiles-operator
+	// must therefore be installed.
+	if useExistingCluster && !hasSelinuxProfiles {
+		exitOnErr(fmt.Errorf("the security-profiles-operator is required to run these tests against an existing cluster, but its API group security-profiles-operator.x-k8s.io was not found; install it first"))
+	}
 
 	// deploy the BPFMAN Operator and relevant CRDs.
 	if !skipBpfmanDeploy {

--- a/test/integration/tc_test.go
+++ b/test/integration/tc_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +29,7 @@ func TestTcGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcGoCounterUserspaceNs, tcGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tc counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcGoCounterKustomize))
+		deleteWorkload(ctx, env.Cluster(), tcGoCounterKustomize)
 	})
 
 	t.Log("waiting for tc counter BPF program to be loaded")
@@ -77,7 +76,7 @@ func TestTcGoCounterLinkPriority(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcGoCounterUserspaceNs, tcGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tc counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcGoCounterKustomize))
+		deleteWorkload(ctx, env.Cluster(), tcGoCounterKustomize)
 
 		cleanupLog("cleaning up tc counter bytecode")
 		bpfmanClient.BpfmanV1alpha1().ClusterBpfApplications().DeleteCollection(ctx, metav1.DeleteOptions{},

--- a/test/integration/tc_test.go
+++ b/test/integration/tc_test.go
@@ -27,10 +27,10 @@ const (
 
 func TestTcGoCounter(t *testing.T) {
 	t.Log("deploying tc counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), tcGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcGoCounterUserspaceNs, tcGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tc counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), tcGoCounterKustomize)
+		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcGoCounterKustomize))
 	})
 
 	t.Log("waiting for tc counter BPF program to be loaded")
@@ -74,10 +74,10 @@ func TestTcGoCounterLinkPriority(t *testing.T) {
 	}
 
 	t.Log("deploying tc counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), tcGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcGoCounterUserspaceNs, tcGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tc counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), tcGoCounterKustomize)
+		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcGoCounterKustomize))
 
 		cleanupLog("cleaning up tc counter bytecode")
 		bpfmanClient.BpfmanV1alpha1().ClusterBpfApplications().DeleteCollection(ctx, metav1.DeleteOptions{},

--- a/test/integration/tc_test.go
+++ b/test/integration/tc_test.go
@@ -47,7 +47,7 @@ func TestTcGoCounter(t *testing.T) {
 
 	pods, err := env.Cluster().Client().CoreV1().Pods(tcGoCounterUserspaceNs).List(ctx, metav1.ListOptions{LabelSelector: "name=go-tc-counter"})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
+	require.NotEmpty(t, pods.Items)
 	gotcCounterPod := pods.Items[0]
 
 	req := env.Cluster().Client().CoreV1().Pods(tcGoCounterUserspaceNs).GetLogs(gotcCounterPod.Name, &corev1.PodLogOptions{})
@@ -117,7 +117,7 @@ func TestTcGoCounterLinkPriority(t *testing.T) {
 
 	pods, err := env.Cluster().Client().CoreV1().Pods(tcGoCounterUserspaceNs).List(ctx, metav1.ListOptions{LabelSelector: "name=go-tc-counter"})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
+	require.NotEmpty(t, pods.Items)
 	goTcCounterPod := pods.Items[0]
 
 	req := env.Cluster().Client().CoreV1().Pods(tcGoCounterUserspaceNs).GetLogs(goTcCounterPod.Name, &corev1.PodLogOptions{})

--- a/test/integration/tcx_test.go
+++ b/test/integration/tcx_test.go
@@ -47,7 +47,7 @@ func TestTcxGoCounter(t *testing.T) {
 
 	pods, err := env.Cluster().Client().CoreV1().Pods(tcxGoCounterUserspaceNs).List(ctx, metav1.ListOptions{LabelSelector: "name=go-tcx-counter"})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
+	require.NotEmpty(t, pods.Items)
 	gotcxCounterPod := pods.Items[0]
 
 	req := env.Cluster().Client().CoreV1().Pods(tcxGoCounterUserspaceNs).GetLogs(gotcxCounterPod.Name, &corev1.PodLogOptions{})
@@ -117,7 +117,7 @@ func TestTcxGoCounterLinkPriority(t *testing.T) {
 
 	pods, err := env.Cluster().Client().CoreV1().Pods(tcxGoCounterUserspaceNs).List(ctx, metav1.ListOptions{LabelSelector: "name=go-tcx-counter"})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
+	require.NotEmpty(t, pods.Items)
 	goTcxCounterPod := pods.Items[0]
 
 	req := env.Cluster().Client().CoreV1().Pods(tcxGoCounterUserspaceNs).GetLogs(goTcxCounterPod.Name, &corev1.PodLogOptions{})

--- a/test/integration/tcx_test.go
+++ b/test/integration/tcx_test.go
@@ -27,10 +27,10 @@ const (
 
 func TestTcxGoCounter(t *testing.T) {
 	t.Log("deploying tcx counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), tcxGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcxGoCounterUserspaceNs, tcxGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tcx counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), tcxGoCounterKustomize)
+		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcxGoCounterKustomize))
 	})
 
 	t.Log("waiting for tcx counter BPF program to be loaded")
@@ -74,10 +74,10 @@ func TestTcxGoCounterLinkPriority(t *testing.T) {
 	}
 
 	t.Log("deploying tcx counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), tcxGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcxGoCounterUserspaceNs, tcxGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tcx counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), tcxGoCounterKustomize)
+		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcxGoCounterKustomize))
 
 		cleanupLog("cleaning up tcx counter bytecode")
 		bpfmanClient.BpfmanV1alpha1().ClusterBpfApplications().DeleteCollection(ctx, metav1.DeleteOptions{},

--- a/test/integration/tcx_test.go
+++ b/test/integration/tcx_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +29,7 @@ func TestTcxGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcxGoCounterUserspaceNs, tcxGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tcx counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcxGoCounterKustomize))
+		deleteWorkload(ctx, env.Cluster(), tcxGoCounterKustomize)
 	})
 
 	t.Log("waiting for tcx counter BPF program to be loaded")
@@ -77,7 +76,7 @@ func TestTcxGoCounterLinkPriority(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), tcxGoCounterUserspaceNs, tcxGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up tcx counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tcxGoCounterKustomize))
+		deleteWorkload(ctx, env.Cluster(), tcxGoCounterKustomize)
 
 		cleanupLog("cleaning up tcx counter bytecode")
 		bpfmanClient.BpfmanV1alpha1().ClusterBpfApplications().DeleteCollection(ctx, metav1.DeleteOptions{},

--- a/test/integration/tracepoint_test.go
+++ b/test/integration/tracepoint_test.go
@@ -25,10 +25,10 @@ const (
 
 func TestTracepointGoCounter(t *testing.T) {
 	t.Log("deploying tracepoint counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), tracepointGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), tracepointGoCounterUserspaceNs, tracepointGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up tracepoint counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), tracepointGoCounterKustomize)
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tracepointGoCounterKustomize))
 	})
 
 	t.Log("waiting for tracepoint counter BPF program to be loaded")

--- a/test/integration/tracepoint_test.go
+++ b/test/integration/tracepoint_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ func TestTracepointGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), tracepointGoCounterUserspaceNs, tracepointGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up tracepoint counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(tracepointGoCounterKustomize))
+		return deleteWorkload(ctx, env.Cluster(), tracepointGoCounterKustomize)
 	})
 
 	t.Log("waiting for tracepoint counter BPF program to be loaded")

--- a/test/integration/uprobe_test.go
+++ b/test/integration/uprobe_test.go
@@ -28,10 +28,10 @@ const (
 
 func TestUprobeGoCounter(t *testing.T) {
 	t.Log("deploying target for uprobe counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), targetKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), targetUserspaceNs, targetKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up target program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), targetKustomize)
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(targetKustomize))
 	})
 
 	t.Log("waiting for go target userspace daemon to be available")
@@ -44,10 +44,10 @@ func TestUprobeGoCounter(t *testing.T) {
 		5*time.Minute, 10*time.Second)
 
 	t.Log("deploying uprobe counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), uprobeGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), uprobeGoCounterUserspaceNs, uprobeGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up uprobe counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), uprobeGoCounterKustomize)
+		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(uprobeGoCounterKustomize))
 	})
 
 	t.Log("waiting for uprobe counter BPF program to be loaded")

--- a/test/integration/uprobe_test.go
+++ b/test/integration/uprobe_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +30,7 @@ func TestUprobeGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), targetUserspaceNs, targetKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up target program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(targetKustomize))
+		return deleteWorkload(ctx, env.Cluster(), targetKustomize)
 	})
 
 	t.Log("waiting for go target userspace daemon to be available")
@@ -47,7 +46,7 @@ func TestUprobeGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), uprobeGoCounterUserspaceNs, uprobeGoCounterKustomize))
 	addCleanup(func(context.Context) error {
 		cleanupLog("cleaning up uprobe counter program")
-		return clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(uprobeGoCounterKustomize))
+		return deleteWorkload(ctx, env.Cluster(), uprobeGoCounterKustomize)
 	})
 
 	t.Log("waiting for uprobe counter BPF program to be loaded")

--- a/test/integration/xdp_test.go
+++ b/test/integration/xdp_test.go
@@ -27,10 +27,10 @@ const (
 
 func TestXdpGoCounter(t *testing.T) {
 	t.Log("deploying xdp counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), xdpGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), xdpGoCounterUserspaceNs, xdpGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up xdp counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), xdpGoCounterKustomize)
+		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(xdpGoCounterKustomize))
 	})
 
 	t.Log("waiting for xdp counter BPF program to be loaded")
@@ -74,10 +74,10 @@ func TestXdpGoCounterLinkPriority(t *testing.T) {
 	}
 
 	t.Log("deploying xdp counter program")
-	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), xdpGoCounterKustomize))
+	require.NoError(t, deployWorkload(ctx, env.Cluster(), xdpGoCounterUserspaceNs, xdpGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up xdp counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), xdpGoCounterKustomize)
+		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(xdpGoCounterKustomize))
 
 		cleanupLog("cleaning up xdp counter bytecode")
 		bpfmanClient.BpfmanV1alpha1().ClusterBpfApplications().DeleteCollection(ctx, metav1.DeleteOptions{},

--- a/test/integration/xdp_test.go
+++ b/test/integration/xdp_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +29,7 @@ func TestXdpGoCounter(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), xdpGoCounterUserspaceNs, xdpGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up xdp counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(xdpGoCounterKustomize))
+		deleteWorkload(ctx, env.Cluster(), xdpGoCounterKustomize)
 	})
 
 	t.Log("waiting for xdp counter BPF program to be loaded")
@@ -77,7 +76,7 @@ func TestXdpGoCounterLinkPriority(t *testing.T) {
 	require.NoError(t, deployWorkload(ctx, env.Cluster(), xdpGoCounterUserspaceNs, xdpGoCounterKustomize))
 	t.Cleanup(func() {
 		cleanupLog("cleaning up xdp counter program")
-		clusters.KustomizeDeleteForCluster(ctx, env.Cluster(), workloadKustomize(xdpGoCounterKustomize))
+		deleteWorkload(ctx, env.Cluster(), xdpGoCounterKustomize)
 
 		cleanupLog("cleaning up xdp counter bytecode")
 		bpfmanClient.BpfmanV1alpha1().ClusterBpfApplications().DeleteCollection(ctx, metav1.DeleteOptions{},

--- a/test/integration/xdp_test.go
+++ b/test/integration/xdp_test.go
@@ -47,7 +47,7 @@ func TestXdpGoCounter(t *testing.T) {
 
 	pods, err := env.Cluster().Client().CoreV1().Pods(xdpGoCounterUserspaceNs).List(ctx, metav1.ListOptions{LabelSelector: "name=go-xdp-counter"})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
+	require.NotEmpty(t, pods.Items)
 	goXdpCounterPod := pods.Items[0]
 
 	req := env.Cluster().Client().CoreV1().Pods(xdpGoCounterUserspaceNs).GetLogs(goXdpCounterPod.Name, &corev1.PodLogOptions{})
@@ -117,7 +117,7 @@ func TestXdpGoCounterLinkPriority(t *testing.T) {
 
 	pods, err := env.Cluster().Client().CoreV1().Pods(xdpGoCounterUserspaceNs).List(ctx, metav1.ListOptions{LabelSelector: "name=go-xdp-counter"})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
+	require.NotEmpty(t, pods.Items)
 	goXdpCounterPod := pods.Items[0]
 
 	req := env.Cluster().Client().CoreV1().Pods(xdpGoCounterUserspaceNs).GetLogs(goXdpCounterPod.Name, &corev1.PodLogOptions{})

--- a/test/lifecycle/lifecycle_test.go
+++ b/test/lifecycle/lifecycle_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"testing"
 	"time"
@@ -50,45 +49,7 @@ const (
 	fieldOwner   = "lifecycle-test"
 )
 
-// Image defaults - overridden by environment variables in CI.
 var (
-	bpfmanImage      = getEnvOrDefault("BPFMAN_IMG", "quay.io/bpfman/bpfman:latest")
-	bpfmanAgentImage = getEnvOrDefault("BPFMAN_AGENT_IMG", "quay.io/bpfman/bpfman-agent:latest")
-)
-
-func getEnvOrDefault(key, defaultValue string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return defaultValue
-}
-
-// Create new Config with modified settings
-var (
-	newConfig = &v1alpha1.Config{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: internal.BpfmanConfigName,
-		},
-		Spec: v1alpha1.ConfigSpec{
-			Namespace: "bpfman",
-			Configuration: `[database]
-max_retries = 35
-millisec_delay = 10000
-[signing]
-allow_unsigned = true
-verify_enabled = true`,
-			Agent: v1alpha1.AgentSpec{
-				Image:           bpfmanAgentImage,
-				LogLevel:        "debug", // Changed from info to debug
-				HealthProbePort: 8175,
-			},
-			Daemon: v1alpha1.DaemonSpec{
-				Image:    bpfmanImage,
-				LogLevel: "bpfman=info",
-			},
-		},
-	}
-
 	runtimeClient client.Client
 	isOpenShift   bool
 	hasMonitoring bool
@@ -282,8 +243,25 @@ func TestLifecycle(t *testing.T) {
 		t.Fatalf("Failed default-config recovery: %q", err)
 	}
 
-	// Test config recreation with modified settings.
+	// Test config recreation with modified settings. Derive the new Config
+	// from the one already running so it keeps the images that deployment
+	// actually uses, changing only the settings under test. Building it from
+	// fixed image values would tell the operator to roll the daemonset to
+	// images this cluster may not be able to pull.
 	t.Logf("Running: TestConfigRecreationWithModifiedSettings")
+	if originalConfig == nil {
+		t.Fatal("no existing Config to base the modified Config on")
+	}
+	newConfig := originalConfig.DeepCopy()
+	newConfig.ObjectMeta = metav1.ObjectMeta{Name: internal.BpfmanConfigName}
+	newConfig.Spec.Configuration = `[database]
+max_retries = 35
+millisec_delay = 10000
+[signing]
+allow_unsigned = true
+verify_enabled = true`
+	newConfig.Spec.Agent.LogLevel = "debug"
+	newConfig.Spec.Daemon.LogLevel = "bpfman=info"
 	if err := testConfigCreation(ctx, t, newConfig); err != nil {
 		t.Fatalf("Failed config recreation: %q", err)
 	}


### PR DESCRIPTION
## Summary

Cherry-pick two upstream PRs from bpfman/bpfman-operator needed for integration testing on OpenShift clusters.

## Upstream PRs included

- [#530](https://github.com/bpfman/bpfman-operator/pull/530) test: run the integration and lifecycle suites against an OpenShift cluster
- [#536](https://github.com/bpfman/bpfman-operator/pull/536) Prefer `KUBECONFIG` over in-cluster config in `GetK8sConfigOrDie`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running OpenShift integration tests against an existing cluster, with a new dedicated test target and configurable timeout.
  * Expanded integration coverage to work with existing clusters and additional test environments.

* **Bug Fixes**
  * Improved Kubernetes config selection so a provided kubeconfig can be used even when running inside a cluster.
  * Made workload deployment more reliable by handling SELinux profile alignment and loosening overly strict pod-count checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->