### PR TITLE
BPFMAN-30: Re-enable `relatedImages` in bundle CSV for disconnected mode support

### DIFF
--- a/hack/openshift/update-bundle.py
+++ b/hack/openshift/update-bundle.py
@@ -196,13 +196,10 @@ def main():
             "image": args.csi_pullspec.strip()
         })
 
-    # Disabled: relatedImages causes EC olm.unmapped_references failures because
-    # the nudged registry.redhat.io refs don't exist yet at validation time.
-    # The release pipeline would need to inject these post-validation.
-    # if related_images:
-    #     if "spec" not in bpfman_operator_csv:
-    #         bpfman_operator_csv["spec"] = {}
-    #     bpfman_operator_csv["spec"]["relatedImages"] = related_images
+    if related_images:
+        if "spec" not in bpfman_operator_csv:
+            bpfman_operator_csv["spec"] = {}
+        bpfman_operator_csv["spec"]["relatedImages"] = related_images
 
     try:
         if args.output == "-":


### PR DESCRIPTION
- Re-enables the `relatedImages` section in the bundle CSV that was disabled by #1432 to work around Enterprise Contract `olm.unmapped_references` validation failures
- The EC validation issue can be addressed via Konflux configuration for the staging release instead of removing `relatedImages`
- Without `relatedImages`, the operator's `disconnected: "true"` annotation is not backed by the actual plumbing — OLM and `oc-mirror` use this section to determine which images need to be mirrored to the local registry for disconnected/air-gapped environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundle generation so image references are included when available, reducing issues caused by missing deployment metadata.
  * Kept existing branding, version, and environment updates unchanged while making the bundle output more complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->