### PR TITLE
Add verify-test stage to operator Containerfile

### DIFF
--- a/Containerfile.bpfman-operator.openshift
+++ b/Containerfile.bpfman-operator.openshift
@@ -3,6 +3,13 @@ ARG BUILDVERSION
 # Build the manager binary
 ARG BUILDPLATFORM
 
+# Verify that all code, including integration tests, compiles successfully.
+# This stage catches build failures early before the main build proceeds.
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:9.8-1782717933 AS verify-test
+WORKDIR /usr/src/bpfman-operator
+COPY . .
+RUN go test -mod vendor -tags=integration_tests -c -o /dev/null ./test/integration/... && touch /tmp/verify-test.done
+
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:9.8-1782717933 AS bpfman-operator-build
 
 ARG BUILDVERSION
@@ -55,6 +62,8 @@ RUN set -euo pipefail; \
     grep -qF "${dst}" "${ds}" \
       || { echo "ERROR: replacement failed in ${ds}"; exit 1; }; \
     rm -f "${ds}.bak"
+
+COPY --from=verify-test /tmp/verify-test.done /tmp/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
## Summary

Add a dedicated `verify-test` build stage to `Containerfile.bpfman-operator.openshift` that compiles all code including integration tests (`-tags=integration_tests`). The `bpfman-operator-build` stage depends on `verify-test` via a `COPY --from`, so the verification runs before the main build proceeds.

This would have caught the `podExec` duplicate symbol introduced by #2037 (cherry-pick of upstream PRs #530 and #536 without their dependency #528).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an additional build verification step that compiles the integration test suite (compile-only) to improve build confidence.
  * The build now includes a completion marker from the verification step in the final build output for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->