### PR TITLE
[TEST] Pin daemon to PR-built Go-rewrite image

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged()
       || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:

--- a/hack/konflux/images/bpfman.txt
+++ b/hack/konflux/images/bpfman.txt
@@ -1,1 +1,1 @@
-registry.redhat.io/bpfman/bpfman@sha256:6ae07cc9d003a9a48b017875fd409cd7955cef104f93000e4265cd870e917bc6
+quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-ystream@sha256:d203d9be8fa0d475103ff62d3ac381be32ba4f4c39c14b2fc45495d6437807ac


### PR DESCRIPTION
This PR updates `hack/konflux/images/bpfman.txt` to point at the downstream bpfman daemon that has been rewritten in Go:

```
quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-ystream@sha256:d203d9be8fa0d475103ff62d3ac381be32ba4f4c39c14b2fc45495d6437807ac
```

The image was built from a bpfman PR and has not gone through the push/promotion pipeline, so it references the `quay.io/redhat-user-workloads/ocp-bpfman-tenant/` staging namespace directly instead of the usual `registry.redhat.io/bpfman/bpfman` pullspec.

**Purpose:** Have Konflux build a test bundle image with the Go-rewrite daemon to validate compatibility with the operator. Not intended for merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

bpfman test PR: https://github.com/openshift/bpfman/pull/734
bpfman build pipeline: [link](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/ocp-bpfman-tenant/applications/bpfman-ystream/pipelineruns/bpfman-daemon-ystream-on-pull-request-m9f7n).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned bpfman container image reference to a newer source and digest.

* **Build & Release**
  * Expanded pull-request PipelineRun trigger conditions to include additional bpfman-related pinned image files, ensuring builds run when these files change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->