### PR TITLE
ci: trigger bundle pipeline on daemon/agent image changes

### DIFF
--- a/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
+++ b/.tekton/bpfman-operator-bundle-ystream-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
       || ".tekton/bpfman-operator-bundle-ystream-push.yaml".pathChanged() || "Containerfile.bundle.openshift".pathChanged()
       || "bundle/***".pathChanged() || "hack/openshift/***".pathChanged() || "config/***".pathChanged()
       || "rpms.in.yaml".pathChanged() || "requirements.txt".pathChanged() || "hack/konflux/images/bpfman-operator.txt".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "hack/konflux/images/bpfman-agent.txt".pathChanged()
       || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:


### PR DESCRIPTION
The bundle PR pipeline's CEL expression only watched `hack/konflux/images/bpfman-operator.txt`, so PRs that update the daemon or agent image digest (e.g. Konflux nudge PRs) never triggered a bundle rebuild on the PR itself.

Add `hack/konflux/images/bpfman.txt` and `hack/konflux/images/bpfman-agent.txt` to the trigger so all three image digest files cause a bundle pipeline run on pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Pull requests that modify additional Konflux image files can now trigger the appropriate validation pipeline.
  * Updated file-change detection to recognize both bpfman and bpfman-agent image paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->